### PR TITLE
chore: remove dead links to the private docs/kfx_toc_research path

### DIFF
--- a/plugin/kfxgen/kfxlib_minimal/README.md
+++ b/plugin/kfxgen/kfxlib_minimal/README.md
@@ -15,7 +15,7 @@ with future upstream syncs. Audit when bumping the upstream baseline.
 | 2025-12-31 | — | (initial) | Trimmed upstream `kfxlib` to the minimum surface needed by kfxgen (Ion binary/text/symbol-table, kfx/yj container, message logging). Heavy deps (pypdf, PIL, lxml-only paths) removed. |
 | 2026-01-05 | — | (foundation) | `standard_symbols.py` and `yj_symbol_catalog.py` populated for native KFX generation (Phase 1 — gap fix + standard symbols). |
 | 2026-02-17 | — | v5.1.0 | Lint pass: unused imports removed, lambda assignment replaced. Mechanical only. |
-| 2026-03-02 | — | v5.2.0 | TOC off-by-one fixes touched serialization paths in this directory. See `docs/kfx_toc_research/` for the full story. |
+| 2026-03-02 | — | v5.2.0 | TOC off-by-one fixes touched serialization paths in this directory. |
 | 2026-05-03 | issue 47 | PR 66 | `Deserializer.extract` length-field bound (`MAX_DECODE_SIZE`, default 64 MB). Negative-size and oversized-size paths raise distinct errors BEFORE the slice. Single choke point defends every length-bounded read in `ion_binary.py`. |
 | 2026-05-03 | issue 47 | (PR D) | `MAX_DECODE_SIZE` accepts `KFXGEN_MAX_DECODE_SIZE` env override at import time. Default unchanged (64 MB). See [SECURITY.md → Advanced configuration](../../../SECURITY.md). |
 | 2026-05-03 | — | PR 56/PR 67 | Pre-commit framework added at repo root; ruff format/lint may have touched files in this directory. Mechanical only. |

--- a/tests/unit/test_kfx_invariants.py
+++ b/tests/unit/test_kfx_invariants.py
@@ -331,11 +331,9 @@ class TestCoverFragmentDivergence:
 class TestStyleMagnitudeIsDecimal:
     """$307 magnitude fields inside $157 style structs MUST be IonDecimal.
 
-    History (#68 disposition): an early note in
-    docs/kfx_toc_research/KFXGEN_NATIVE_GENERATOR_ISSUES.md (2025-12)
-    claimed `$307` should be plain int. This was overruled by the
-    Calibre KFX output gold standard (a real-book reference KFX in
-    the maintainer's gitignored research/ directory), which uses
+    History: an early 2025-12 note claimed `$307` should be plain int.
+    This was overruled by the Calibre KFX output gold standard (a
+    reference KFX in the maintainer's gitignored research/ directory), which uses
     Decimal for every $307 in $157 — across
     $48 (margin-bottom), $42 (line-height), $16 (font-size), $36
     (text-indent), $46 (margin-top), $47 (padding-top). The shipping


### PR DESCRIPTION
## What
Two comments/docstrings in the public repo pointed at `docs/kfx_toc_research/`, which exists only in the private dev repo (`kfxgen-dev`). In this public repo those paths resolve to nothing.

- `tests/unit/test_kfx_invariants.py` — drop the `docs/kfx_toc_research/KFXGEN_NATIVE_GENERATOR_ISSUES.md` pointer from the `$307`-is-Decimal docstring; also drop the now-redundant "real-book" qualifier on the reference-KFX mention.
- `plugin/kfxgen/kfxlib_minimal/README.md` — drop the "See `docs/kfx_toc_research/` for the full story" pointer.

No behavior change (comments/docstrings only).

## Note on "real-book corpus"
Left as-is intentionally. It accurately refers to the maintainer's private, gitignored, **copyrighted** device-test EPUBs — which are distinct from the public-domain **Project Gutenberg** 90-book baseline corpus (already called out by name in the README). The surrounding text is already transparent that those bytes are copyrighted and deliberately not committed. No titles or content are exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)