### PR TITLE
release: v5.3.16 — packaging + release automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 5.3.16 — Packaging and release automation
+
+Maintenance release. No runtime behavior change from 5.3.15.
+
+- Releases are now built and published automatically: pushing a `vX.Y.Z`
+  tag builds the plugin zip and attaches it to a GitHub Release (the tag
+  must match `version` in `plugin/kfxgen/__init__.py`).
+- Removed stale references to internal-only documentation paths from a
+  test docstring and the `kfxlib_minimal` README.
+
 ## 5.3.15 — Crash fix for chapters with no renderable content
 
 Fixes an `IndexError: list index out of range` in

--- a/plugin/kfxgen/__init__.py
+++ b/plugin/kfxgen/__init__.py
@@ -12,7 +12,7 @@ __copyright__ = "2025-2026, Justin Loutsch <justin.loutsch@gmail.com>"
 
 #: Version tuple. Bump this for every release; the plugin wrapper and
 #: converter log message read from here.
-version = (5, 3, 15)
+version = (5, 3, 16)
 __version__ = ".".join(str(x) for x in version)
 
 __all__ = [


### PR DESCRIPTION
Bumps `version` 5.3.15 → 5.3.16 (`plugin/kfxgen/__init__.py`) and adds the CHANGELOG entry.

Maintenance release — **no runtime behavior change**. It exists to validate the new tag-triggered release workflow end-to-end and to roll the packaging/docs cleanup into a published version.

After merge: `git tag v5.3.16 && git push origin v5.3.16` → the release workflow builds and publishes `kfxgen-plugin-5.3.16.zip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)