### PR TITLE
chore: restore GPL attribution for vendored kfxlib (John Howell)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,27 @@
+kfxgen
+Copyright (C) 2025-2026 Justin Loutsch <justin.loutsch@gmail.com>
+
+This program is free software licensed under the GNU General Public
+License v3. See the LICENSE file for the full terms.
+
+------------------------------------------------------------------------
+Third-party code
+------------------------------------------------------------------------
+
+plugin/kfxgen/kfxlib_minimal/
+
+    A modified subset of Calibre's "kfxlib", from the KFX Input/Output
+    plugins by John Howell <jhowell@acm.org>.
+
+    Copyright (C) 2016-2025 John Howell <jhowell@acm.org>
+    Licensed under the GNU General Public License v3.
+
+    kfxgen vendors and modifies this code: the library was trimmed to the
+    Ion/KFX serialization surface kfxgen needs, with security and
+    packaging changes on top. The list of local modifications is kept in
+    plugin/kfxgen/kfxlib_minimal/README.md.
+
+    The upstream KFX plugins are available from the MobileRead forums.
+    kfxgen does not redistribute jhowell's plugin packages themselves;
+    only this modified source subset is included, as permitted by the
+    GPL v3 it is licensed under.

--- a/README.md
+++ b/README.md
@@ -143,13 +143,13 @@ Adversarial-EPUB threat model and reporting process: see [`SECURITY.md`](SECURIT
 
 ## License
 
-GPL v3 — see [LICENSE](LICENSE) for the full text.
+GPL v3 — see [LICENSE](LICENSE) for the full text, and [NOTICE](NOTICE) for third-party attribution.
 
 Copyright © 2025-2026 Justin Loutsch &lt;justin.loutsch@gmail.com&gt;
 
 ## Credits
 
-- **kfxlib** by John Howell — Ion/KFX libraries (the `kfxlib_minimal/` directory is derived from this work)
+- **kfxlib** by John Howell — Ion/KFX libraries, GPL v3. The `kfxlib_minimal/` directory is a modified subset of this work; see [NOTICE](NOTICE) and `plugin/kfxgen/kfxlib_minimal/README.md`.
 - **Calibre** by Kovid Goyal — plugin framework
 
 ---

--- a/build_plugin.sh
+++ b/build_plugin.sh
@@ -77,10 +77,14 @@ ABOUT
 mkdir -p "$DIST_DIR"
 rm -f "$OUT"
 
-# Bundle LICENSE inside the plugin zip so users who install via
-# `calibre-customize -a` have the license text alongside the code.
+# Bundle LICENSE + NOTICE inside the plugin zip so users who install via
+# `calibre-customize -a` have the license text and third-party attribution
+# alongside the code.
 if [ -f "$ROOT/LICENSE" ]; then
   cp "$ROOT/LICENSE" "$BUILD_DIR/LICENSE"
+fi
+if [ -f "$ROOT/NOTICE" ]; then
+  cp "$ROOT/NOTICE" "$BUILD_DIR/NOTICE"
 fi
 
 (cd "$BUILD_DIR" && zip -rq "$OUT" .)

--- a/plugin/kfxgen/kfxlib_minimal/ion_binary.py
+++ b/plugin/kfxgen/kfxlib_minimal/ion_binary.py
@@ -1,3 +1,9 @@
+# Part of kfxgen's kfxlib_minimal: a modified subset of Calibre's kfxlib
+# (the KFX plugins by John Howell). See kfxlib_minimal/README.md for the
+# list of local modifications.
+__license__ = "GPL v3"
+__copyright__ = "2016-2025, John Howell <jhowell@acm.org>"
+
 import decimal
 import logging
 import struct

--- a/plugin/kfxgen/kfxlib_minimal/ion_symbol_table.py
+++ b/plugin/kfxgen/kfxlib_minimal/ion_symbol_table.py
@@ -1,3 +1,9 @@
+# Part of kfxgen's kfxlib_minimal: a modified subset of Calibre's kfxlib
+# (the KFX plugins by John Howell). See kfxlib_minimal/README.md for the
+# list of local modifications.
+__license__ = "GPL v3"
+__copyright__ = "2016-2025, John Howell <jhowell@acm.org>"
+
 import re
 
 from .ion import (

--- a/plugin/kfxgen/kfxlib_minimal/ion_text.py
+++ b/plugin/kfxgen/kfxlib_minimal/ion_text.py
@@ -1,3 +1,9 @@
+# Part of kfxgen's kfxlib_minimal: a modified subset of Calibre's kfxlib
+# (the KFX plugins by John Howell). See kfxlib_minimal/README.md for the
+# list of local modifications.
+__license__ = "GPL v3"
+__copyright__ = "2016-2025, John Howell <jhowell@acm.org>"
+
 import datetime
 import decimal
 import base64

--- a/plugin/kfxgen/kfxlib_minimal/kfx_container.py
+++ b/plugin/kfxgen/kfxlib_minimal/kfx_container.py
@@ -1,3 +1,9 @@
+# Part of kfxgen's kfxlib_minimal: a modified subset of Calibre's kfxlib
+# (the KFX plugins by John Howell). See kfxlib_minimal/README.md for the
+# list of local modifications.
+__license__ = "GPL v3"
+__copyright__ = "2016-2025, John Howell <jhowell@acm.org>"
+
 import copy
 
 from .ion import IonBLOB, IonAnnotation, IonStruct, IS

--- a/plugin/kfxgen/kfxlib_minimal/standard_symbols.py
+++ b/plugin/kfxgen/kfxlib_minimal/standard_symbols.py
@@ -1,3 +1,9 @@
+# Part of kfxgen's kfxlib_minimal: a modified subset of Calibre's kfxlib
+# (the KFX plugins by John Howell). See kfxlib_minimal/README.md for the
+# list of local modifications.
+__license__ = "GPL v3"
+__copyright__ = "2016-2025, John Howell <jhowell@acm.org>"
+
 from .ion_symbol_table import LocalSymbolTable
 
 STANDARD_SYMBOLS = [

--- a/plugin/kfxgen/kfxlib_minimal/utilities.py
+++ b/plugin/kfxgen/kfxlib_minimal/utilities.py
@@ -1,3 +1,9 @@
+# Part of kfxgen's kfxlib_minimal: a modified subset of Calibre's kfxlib
+# (the KFX plugins by John Howell). See kfxlib_minimal/README.md for the
+# list of local modifications.
+__license__ = "GPL v3"
+__copyright__ = "2016-2025, John Howell <jhowell@acm.org>"
+
 import atexit
 import base64
 import collections


### PR DESCRIPTION
## Why
`plugin/kfxgen/kfxlib_minimal/` is a modified subset of Calibre's `kfxlib` (John Howell's KFX plugins), licensed **GPL v3**. Six derived files had lost their copyright/license headers during the original trim — a GPL v3 §5 compliance gap (derived works must keep copyright notices intact and mark modifications).

## What
- Re-add `__copyright__` (John Howell) + `__license__ = "GPL v3"` and a "modified subset of Calibre's kfxlib" note to: `ion_binary.py`, `ion_symbol_table.py`, `ion_text.py`, `kfx_container.py`, `standard_symbols.py`, `utilities.py`. (The other four files already had the header.)
- Add a top-level **`NOTICE`** crediting John Howell / kfxlib (GPL v3) and stating the code is modified; `build_plugin.sh` now bundles `NOTICE` into the plugin zip alongside `LICENSE`.
- README: note GPL v3 and link `NOTICE` from the License and Credits sections.

No runtime behavior change. All six edited modules `py_compile` cleanly; the rebuilt zip contains both `LICENSE` and `NOTICE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)