### PR TITLE
release: v5.3.17 — GPL attribution for vendored kfxlib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 5.3.17 — GPL attribution for vendored kfxlib
+
+Licensing-compliance release. No runtime behavior change from 5.3.16.
+
+- Restored the GPL v3 copyright/license headers (John Howell) on the six
+  `kfxlib_minimal` files that had lost them during the original trim, and
+  marked them as a modified subset of Calibre's `kfxlib`.
+- Added a top-level `NOTICE` crediting John Howell / `kfxlib` (GPL v3);
+  it now ships inside the plugin zip alongside `LICENSE`.
+
 ## 5.3.16 — Packaging and release automation
 
 Maintenance release. No runtime behavior change from 5.3.15.

--- a/plugin/kfxgen/__init__.py
+++ b/plugin/kfxgen/__init__.py
@@ -12,7 +12,7 @@ __copyright__ = "2025-2026, Justin Loutsch <justin.loutsch@gmail.com>"
 
 #: Version tuple. Bump this for every release; the plugin wrapper and
 #: converter log message read from here.
-version = (5, 3, 16)
+version = (5, 3, 17)
 __version__ = ".".join(str(x) for x in version)
 
 __all__ = [


### PR DESCRIPTION
Bumps `version` 5.3.16 → 5.3.17 (`plugin/kfxgen/__init__.py`) + CHANGELOG entry.

Licensing-compliance release: ships the restored John Howell / kfxlib GPL v3 headers (#4) and the new `NOTICE` file inside the published plugin zip. No runtime behavior change.

After merge: `git tag v5.3.17 && git push origin v5.3.17` → the release workflow rebuilds and publishes `kfxgen-plugin-5.3.17.zip` with attribution included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)