### PR TITLE
release: v5.3.18 — rename plugin to "kfxgen"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 5.3.18 — Plugin renamed to "kfxgen"
+
+The Calibre plugin now registers as **kfxgen** (previously `KFXGEN`, while
+the docs incorrectly called it "KFX Output (kfxgen)"). This disambiguates
+it from John Howell's "KFX Output" plugin and makes the name consistent
+across the plugin list, `about.txt`, and the docs.
+
+- `name = "kfxgen"` in the plugin wrapper.
+- Fixed install/uninstall docs to use the real name (the old
+  `--disable-plugin "KFX Output (kfxgen)"` command was wrong and would
+  have failed).
+
+Note for anyone who installed an earlier build: Calibre keys plugins by
+name, so the renamed plugin installs as a new entry. Remove the old
+`KFXGEN` plugin once to avoid a duplicate
+(`calibre-customize -r KFXGEN`).
+
 ## 5.3.17 — GPL attribution for vendored kfxlib
 
 Licensing-compliance release. No runtime behavior change from 5.3.16.

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -23,7 +23,7 @@
 5. **Confirm Installation**
    - Calibre will ask: "Are you sure you want to proceed?"
    - Click `Yes`
-   - You should see: "KFX Output (kfxgen)" in the File type plugins list
+   - You should see: "kfxgen" in the File type plugins list
 
 6. **Restart Calibre**
    - Close and reopen Calibre
@@ -65,7 +65,7 @@
 After installation, verify the plugin is active:
 
 1. Go to `Preferences → Plugins`
-2. Look for `KFX Output (kfxgen)` under "File type plugins"
+2. Look for `kfxgen` under "File type plugins"
 3. It should show version `0.1.0`
 
 ### Conversion Working
@@ -107,7 +107,7 @@ A generated KFX file should be:
 
 - **Restart Calibre** (required after installation)
 - Check under `Preferences → Plugins → File type plugins`
-- Look for "KFX Output (kfxgen)"
+- Look for "kfxgen"
 
 ### Conversion Fails
 
@@ -183,7 +183,7 @@ Currently available options:
 To remove the plugin:
 
 1. Go to `Preferences → Plugins`
-2. Find `KFX Output (kfxgen)` under File type plugins
+2. Find `kfxgen` under File type plugins
 3. Right-click → `Remove plugin`
 4. Restart Calibre
 

--- a/build_plugin.sh
+++ b/build_plugin.sh
@@ -63,7 +63,7 @@ echo "kfxgen" > "$BUILD_DIR/plugin-import-name-kfxgen.txt"
 
 # Generated about.txt — sourced from the actual license/version.
 cat > "$BUILD_DIR/about.txt" <<ABOUT
-KFX Output (kfxgen) — Open Source KFX Converter for Calibre
+kfxgen — Open Source KFX Converter for Calibre
 
 Version: $VERSION
 License: GPL v3

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -36,7 +36,7 @@ class KFXGenOutputPlugin(OutputFormatPlugin):
     - Optional Kindle Previewer fallback for complex books
     """
 
-    name = "KFXGEN"
+    name = "kfxgen"
     description = "Native KFX generation, blazing fast. Builds Kindle-ready KFX ebooks in seconds — no Kindle Previewer round-trip, no external tools, just pure Python. A drop-in replacement for KFX Output, only quicker."
     supported_platforms = ["windows", "osx", "linux"]
     author = "Justin Loutsch"

--- a/plugin/kfxgen/__init__.py
+++ b/plugin/kfxgen/__init__.py
@@ -12,7 +12,7 @@ __copyright__ = "2025-2026, Justin Loutsch <justin.loutsch@gmail.com>"
 
 #: Version tuple. Bump this for every release; the plugin wrapper and
 #: converter log message read from here.
-version = (5, 3, 17)
+version = (5, 3, 18)
 __version__ = ".".join(str(x) for x in version)
 
 __all__ = [

--- a/tools/README.md
+++ b/tools/README.md
@@ -52,7 +52,7 @@ one from kfxgen and one from jhowell's `KFX Output`. To generate the
 reference:
 
 1. Install jhowell's plugin (`KFX Output` from MobileRead) in Calibre.
-2. Disable kfxgen (`calibre-customize --disable-plugin "KFX Output (kfxgen)"`)
+2. Disable kfxgen (`calibre-customize --disable-plugin "kfxgen"`)
    so the file extension resolves to jhowell's plugin.
 3. Run `ebook-convert <input.epub> <ref.kfx>`.
 


### PR DESCRIPTION
## What
Registers the Calibre plugin as **`kfxgen`** (was `KFXGEN`; docs incorrectly said "KFX Output (kfxgen)"). Aligns the name across the plugin list, generated `about.txt`, and all docs.

- `plugin/__init__.py`: `name = "kfxgen"`.
- `INSTALLATION.md`, `build_plugin.sh` (about.txt), `tools/README.md`: use the real name. Fixes the broken `calibre-customize --disable-plugin "KFX Output (kfxgen)"` command (wrong name → would have failed).
- Version bump 5.3.17 → 5.3.18 + CHANGELOG.

## Why
Disambiguates from John Howell's "KFX Output" plugin and removes a docs/code mismatch.

## Migration note
Calibre keys plugins by name, so for anyone on an earlier build the rename installs as a new entry; remove the old one once with `calibre-customize -r KFXGEN`. (Install base is ~nil — repo published today.)

After merge: tag `v5.3.18` → release workflow publishes `kfxgen-plugin-5.3.18.zip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)