### PR TITLE
Automatic image optimization for image-heavy books (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 5.3.20 — Fix image optimization no-op
+
+Image optimization shipped in 5.3.19 never actually ran. `calibre.utils.img.scale_image`
+returns a 3-tuple `(width, height, data)`, but the code unpacked it as a
+2-tuple, raising `ValueError` on every image. The error was swallowed and each
+image kept its original size, so image-heavy books were unaffected.
+
+- Unpack `scale_image`'s real 3-tuple return in `optimize_image`.
+- Fix the unit-test mocks, which returned a 2-tuple and so masked the bug.
+- Verified end-to-end: a 308 MB conversion drops to 227 MB (26% off images).
+- Re-closes #11 (5.3.19 closed it but the feature was non-functional).
+
 ## 5.3.19 — Automatic image optimization
 
 Heavily illustrated books no longer produce huge KFX files. Images whose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 5.3.19 — Automatic image optimization
+
+Heavily illustrated books no longer produce huge KFX files. Images whose
+longest edge exceeds 2048 px are downscaled and recompressed (JPEG quality
+85; PNG kept as PNG) during conversion.
+
+- On by default. Disable with the **Embed original images** output option
+  (CLI `--kfxgen-embed-original-images`).
+- Tunable via `KFXGEN_IMAGE_MAX_DIM` and `KFXGEN_IMAGE_QUALITY`.
+- Closes #11.
+
 ## 5.3.18 — Plugin renamed to "kfxgen"
 
 The Calibre plugin now registers as **kfxgen** (previously `KFXGEN`, while

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The version is single-sourced from `plugin/kfxgen/__init__.py`. `./build_plugin.
 - TOC entries that navigate within a spine file via `#anchor` (e.g. dictionary-style A/B/C/… sub-entries) surface as separate chapters rather than nested in-page anchors. Reading order and content are preserved.
 - Fonts are not embedded in the KFX. Custom fonts render via the font installed on the Kindle (see [Why this plugin](#why-this-plugin)); this is by design, but it means a font that isn't installed on the device won't travel with the file.
 - Inline emphasis (italic / bold within a paragraph) and most source CSS typography are not yet carried through; paragraph-level styles (font size, line height, alignment, margins, headings) are. KFX supports a subset of CSS, so this is a coverage gap rather than a hard limit — tracked in [#9](https://github.com/jloutsch/kfxgen/issues/9).
-- Images are embedded at source resolution with no downscaling or recompression, so heavily illustrated books can produce very large KFX files (a 469-image book yielded ~300 MB). Image optimization is tracked in [#11](https://github.com/jloutsch/kfxgen/issues/11).
+- Images larger than 2048 px on the long edge are automatically downscaled and recompressed (JPEG quality 85) so illustrated books stay a reasonable size. To keep originals, enable **Embed original images** in the KFX output options (CLI: `--kfxgen-embed-original-images`). Tune with `KFXGEN_IMAGE_MAX_DIM` and `KFXGEN_IMAGE_QUALITY`.
 
 ## Version history
 

--- a/docs/superpowers/plans/2026-06-27-image-optimization.md
+++ b/docs/superpowers/plans/2026-06-27-image-optimization.md
@@ -1,0 +1,668 @@
+# Image Optimization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Downscale and recompress over-size images during KFX conversion so heavily illustrated books produce device-friendly files, on by default with an escape hatch.
+
+**Architecture:** A new pure-ish module `plugin/kfxgen/image_optimize.py` exposes `optimize_image` (single image) and `optimize_images` (cover + body dict). Dimension is read with a dependency-free header parser; the actual resize/re-encode uses `calibre.utils.img`, lazily imported, with a no-op fallback when unavailable (CI / non-Calibre). `convert_oeb_to_kfx` calls `optimize_images` as a distinct stage unless the user set the "Embed original images" option.
+
+**Tech Stack:** Python 3.13, pytest, `calibre.utils.img` (runtime only; mocked in tests).
+
+## Global Constraints
+
+- Python interpreter: Calibre's bundled Python; minimum Calibre 5.0.
+- No new third-party dependencies (plugin path uses `calibre.utils.img`, already present).
+- Optimization MUST never raise into the conversion — any failure falls back to original bytes.
+- Default max long edge = 2048 px; default JPEG quality = 85.
+- Only act on images whose longest edge exceeds max_dim; images at/under the limit are returned byte-identical (keeps golden fixtures unchanged).
+- Env-var overrides: `KFXGEN_IMAGE_MAX_DIM`, `KFXGEN_IMAGE_QUALITY` (validated; fall back to default on invalid/out-of-range).
+- Escape hatch: Calibre option `kfxgen_embed_original_images` (default False).
+- Work happens in the public repo clone on a feature branch; land via PR.
+
+---
+
+### Task 1: Image size parser + env-var reader
+
+**Files:**
+- Create: `plugin/kfxgen/image_optimize.py`
+- Test: `tests/unit/test_image_optimize.py`
+
+**Interfaces:**
+- Produces: `_read_image_size(data: bytes) -> tuple[int, int] | None`; `_read_env_int(name: str, default: int, lo: int, hi: int, log) -> int`; module constants `DEFAULT_MAX_DIM = 2048`, `DEFAULT_JPEG_QUALITY = 85`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_image_optimize.py
+import struct
+import pytest
+from kfxgen import image_optimize as io
+
+
+def _png(w, h):
+    return (b"\x89PNG\r\n\x1a\n" + struct.pack(">I", 13) + b"IHDR"
+            + struct.pack(">II", w, h) + b"\x08\x02\x00\x00\x00")
+
+
+def _jpeg(w, h):
+    # SOI, APP0 stub, SOF0 (len=17, precision=8, height, width), EOI
+    app0 = b"\xff\xe0" + struct.pack(">H", 16) + b"JFIF\x00" + b"\x01\x01\x00" + b"\x00\x01\x00\x01\x00\x00"
+    sof0 = b"\xff\xc0" + struct.pack(">H", 17) + b"\x08" + struct.pack(">HH", h, w) + b"\x03\x01\x22\x00\x02\x11\x01\x03\x11\x01"
+    return b"\xff\xd8" + app0 + sof0 + b"\xff\xd9"
+
+
+class _Log:
+    def __init__(self): self.warns = []
+    def warn(self, m): self.warns.append(m)
+    def info(self, m): pass
+    def debug(self, m): pass
+
+
+def test_read_size_png():
+    assert io._read_image_size(_png(3000, 2000)) == (3000, 2000)
+
+
+def test_read_size_jpeg():
+    assert io._read_image_size(_jpeg(2500, 1800)) == (2500, 1800)
+
+
+def test_read_size_unknown_returns_none():
+    assert io._read_image_size(b"not an image") is None
+    assert io._read_image_size(b"\xff\xd8short") is None
+
+
+def test_env_int_default_when_unset(monkeypatch):
+    monkeypatch.delenv("KFXGEN_IMAGE_MAX_DIM", raising=False)
+    assert io._read_env_int("KFXGEN_IMAGE_MAX_DIM", 2048, 16, 20000, _Log()) == 2048
+
+
+def test_env_int_valid(monkeypatch):
+    monkeypatch.setenv("KFXGEN_IMAGE_MAX_DIM", "1600")
+    assert io._read_env_int("KFXGEN_IMAGE_MAX_DIM", 2048, 16, 20000, _Log()) == 1600
+
+
+def test_env_int_invalid_falls_back(monkeypatch):
+    monkeypatch.setenv("KFXGEN_IMAGE_MAX_DIM", "huge")
+    log = _Log()
+    assert io._read_env_int("KFXGEN_IMAGE_MAX_DIM", 2048, 16, 20000, log) == 2048
+    assert log.warns
+
+
+def test_env_int_out_of_range_falls_back(monkeypatch):
+    monkeypatch.setenv("KFXGEN_IMAGE_QUALITY", "999")
+    assert io._read_env_int("KFXGEN_IMAGE_QUALITY", 85, 1, 100, _Log()) == 85
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_image_optimize.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'kfxgen.image_optimize'` (or import error).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# plugin/kfxgen/image_optimize.py
+"""Image optimization for KFX output (#11).
+
+Downscales and recompresses over-size images so heavily illustrated books
+produce device-friendly KFX. On by default in the conversion path. The actual
+resize uses calibre.utils.img at runtime; outside Calibre (tests/CI) it is a
+no-op so it never breaks anything.
+"""
+
+import os
+import struct
+
+DEFAULT_MAX_DIM = 2048
+DEFAULT_JPEG_QUALITY = 85
+
+_PNG_SIG = b"\x89PNG\r\n\x1a\n"
+# JPEG Start-Of-Frame markers that carry image dimensions.
+_SOF_MARKERS = {0xC0, 0xC1, 0xC2, 0xC3, 0xC5, 0xC6, 0xC7,
+                0xC9, 0xCA, 0xCB, 0xCD, 0xCE, 0xCF}
+
+
+def _read_image_size(data):
+    """Return (width, height) for PNG or JPEG bytes, else None."""
+    if len(data) >= 24 and data[:8] == _PNG_SIG:
+        w, h = struct.unpack(">II", data[16:24])
+        return (int(w), int(h))
+    if data[:2] == b"\xff\xd8":  # JPEG SOI
+        i, n = 2, len(data)
+        while i + 1 < n:
+            if data[i] != 0xFF:
+                i += 1
+                continue
+            marker = data[i + 1]
+            if marker == 0xFF:
+                i += 1
+                continue
+            if marker in (0xD8, 0xD9) or 0xD0 <= marker <= 0xD7:
+                i += 2
+                continue
+            if i + 4 > n:
+                break
+            seg_len = struct.unpack(">H", data[i + 2:i + 4])[0]
+            if marker in _SOF_MARKERS:
+                if i + 9 <= n:
+                    h, w = struct.unpack(">HH", data[i + 5:i + 9])
+                    return (int(w), int(h))
+                break
+            i += 2 + seg_len
+        return None
+    return None
+
+
+def _read_env_int(name, default, lo, hi, log):
+    """Read an int env var, falling back to default on missing/invalid/range."""
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        n = int(raw)
+    except (TypeError, ValueError):
+        log.warn(f"  ignoring invalid {name}={raw!r} (not an integer); using {default}")
+        return default
+    if n < lo or n > hi:
+        log.warn(f"  ignoring out-of-range {name}={n} (allowed {lo}-{hi}); using {default}")
+        return default
+    return n
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_image_optimize.py -v`
+Expected: PASS (all 7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugin/kfxgen/image_optimize.py tests/unit/test_image_optimize.py
+git commit -m "feat(images): image size parser + env-var reader (#11)"
+```
+
+---
+
+### Task 2: `optimize_image` single-image optimizer
+
+**Files:**
+- Modify: `plugin/kfxgen/image_optimize.py`
+- Test: `tests/unit/test_image_optimize.py`
+
+**Interfaces:**
+- Consumes: `_read_image_size`, `DEFAULT_MAX_DIM`, `DEFAULT_JPEG_QUALITY` (Task 1).
+- Produces: `optimize_image(data: bytes, *, max_dim=2048, jpeg_quality=85, log=None) -> bytes`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/unit/test_image_optimize.py
+import sys
+import types
+
+
+def test_optimize_image_small_is_identity():
+    data = _jpeg(800, 600)
+    assert io.optimize_image(data, max_dim=2048, log=_Log()) is data
+
+
+def test_optimize_image_no_calibre_is_noop():
+    # calibre.utils.img is absent in CI -> over-size image returns unchanged
+    big = _jpeg(4000, 3000)
+    assert io.optimize_image(big, max_dim=2048, log=_Log()) == big
+
+
+def test_optimize_image_downscales_via_calibre(monkeypatch):
+    calls = {}
+    fake = types.ModuleType("calibre.utils.img")
+
+    def scale_image(data, width, height, as_png=False, compression_quality=90):
+        calls["args"] = (width, height, as_png, compression_quality)
+        return ("JPEG", b"small-bytes")
+
+    fake.scale_image = scale_image
+    monkeypatch.setitem(sys.modules, "calibre", types.ModuleType("calibre"))
+    monkeypatch.setitem(sys.modules, "calibre.utils", types.ModuleType("calibre.utils"))
+    monkeypatch.setitem(sys.modules, "calibre.utils.img", fake)
+
+    big = _jpeg(4000, 3000)
+    out = io.optimize_image(big, max_dim=2048, jpeg_quality=85, log=_Log())
+    assert out == b"small-bytes"
+    assert calls["args"] == (2048, 2048, False, 85)
+
+
+def test_optimize_image_keeps_png_format(monkeypatch):
+    seen = {}
+    fake = types.ModuleType("calibre.utils.img")
+
+    def scale_image(data, width, height, as_png=False, compression_quality=90):
+        seen["as_png"] = as_png
+        return ("PNG", b"x" * 10)
+
+    fake.scale_image = scale_image
+    monkeypatch.setitem(sys.modules, "calibre", types.ModuleType("calibre"))
+    monkeypatch.setitem(sys.modules, "calibre.utils", types.ModuleType("calibre.utils"))
+    monkeypatch.setitem(sys.modules, "calibre.utils.img", fake)
+
+    out = io.optimize_image(_png(4000, 3000), max_dim=2048, log=_Log())
+    assert seen["as_png"] is True
+    assert out == b"x" * 10
+
+
+def test_optimize_image_keeps_original_if_result_larger(monkeypatch):
+    fake = types.ModuleType("calibre.utils.img")
+    fake.scale_image = lambda *a, **k: ("JPEG", b"Z" * 100000)
+    monkeypatch.setitem(sys.modules, "calibre", types.ModuleType("calibre"))
+    monkeypatch.setitem(sys.modules, "calibre.utils", types.ModuleType("calibre.utils"))
+    monkeypatch.setitem(sys.modules, "calibre.utils.img", fake)
+
+    big = _jpeg(4000, 3000)
+    assert io.optimize_image(big, max_dim=2048, log=_Log()) == big
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_image_optimize.py -k optimize_image -v`
+Expected: FAIL — `AttributeError: module 'kfxgen.image_optimize' has no attribute 'optimize_image'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# append to plugin/kfxgen/image_optimize.py
+
+def optimize_image(data, *, max_dim=DEFAULT_MAX_DIM, jpeg_quality=DEFAULT_JPEG_QUALITY, log=None):
+    """Downscale + recompress an over-size JPEG/PNG.
+
+    Returns optimized bytes, or the original bytes unchanged when no
+    optimization applies, calibre is unavailable, or anything fails.
+    Never raises.
+    """
+    size = _read_image_size(data)
+    if size is None:
+        return data
+    if max(size) <= max_dim:
+        return data
+    is_png = data[:8] == _PNG_SIG
+    try:
+        from calibre.utils.img import scale_image
+    except Exception:
+        if log:
+            log.debug("  calibre.utils.img unavailable; leaving image at original size")
+        return data
+    try:
+        # scale_image fits within the (width, height) box, preserving aspect.
+        _fmt, out = scale_image(
+            data, width=max_dim, height=max_dim,
+            as_png=is_png, compression_quality=jpeg_quality,
+        )
+    except Exception as e:  # noqa: BLE001 - never fail a conversion over an image
+        if log:
+            log.warn(f"  image optimize failed ({e}); keeping original")
+        return data
+    if not out or len(out) >= len(data):
+        return data
+    return out
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_image_optimize.py -v`
+Expected: PASS (all tests, Task 1 + Task 2).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugin/kfxgen/image_optimize.py tests/unit/test_image_optimize.py
+git commit -m "feat(images): optimize_image with calibre downscale + no-op fallback (#11)"
+```
+
+---
+
+### Task 3: `optimize_images` cover + body wrapper
+
+**Files:**
+- Modify: `plugin/kfxgen/image_optimize.py`
+- Test: `tests/unit/test_image_optimize.py`
+
+**Interfaces:**
+- Consumes: `optimize_image`, `_read_env_int`, `DEFAULT_MAX_DIM`, `DEFAULT_JPEG_QUALITY`.
+- Produces: `optimize_images(cover_image: bytes | None, images: dict[str, bytes], log) -> tuple[bytes | None, dict[str, bytes]]`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/unit/test_image_optimize.py
+
+def test_optimize_images_maps_all_and_handles_none_cover(monkeypatch):
+    # Force the per-image optimizer to a deterministic stub.
+    monkeypatch.setattr(io, "optimize_image",
+                        lambda data, **k: b"OPT" + data[:1])
+    cover, imgs = io.optimize_images(None, {"a.jpg": b"AAAA", "b.png": b"BBBB"}, _Log())
+    assert cover is None
+    assert imgs == {"a.jpg": b"OPTA", "b.png": b"OPTB"}
+
+
+def test_optimize_images_optimizes_cover(monkeypatch):
+    monkeypatch.setattr(io, "optimize_image", lambda data, **k: b"C")
+    cover, imgs = io.optimize_images(b"COVERDATA", {}, _Log())
+    assert cover == b"C"
+    assert imgs == {}
+
+
+def test_optimize_images_reads_env_overrides(monkeypatch):
+    seen = {}
+    monkeypatch.setenv("KFXGEN_IMAGE_MAX_DIM", "1600")
+    monkeypatch.setenv("KFXGEN_IMAGE_QUALITY", "70")
+
+    def spy(data, *, max_dim, jpeg_quality, log):
+        seen["max_dim"] = max_dim
+        seen["q"] = jpeg_quality
+        return data
+
+    monkeypatch.setattr(io, "optimize_image", spy)
+    io.optimize_images(b"COVER", {"a.jpg": b"AAAA"}, _Log())
+    assert seen["max_dim"] == 1600
+    assert seen["q"] == 70
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_image_optimize.py -k optimize_images -v`
+Expected: FAIL — `AttributeError: ... has no attribute 'optimize_images'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# append to plugin/kfxgen/image_optimize.py
+
+_MIN_MAX_DIM, _MAX_MAX_DIM = 16, 20000
+
+
+def optimize_images(cover_image, images, log):
+    """Optimize the cover and every body image. Returns (cover, images)."""
+    max_dim = _read_env_int("KFXGEN_IMAGE_MAX_DIM", DEFAULT_MAX_DIM,
+                            _MIN_MAX_DIM, _MAX_MAX_DIM, log)
+    quality = _read_env_int("KFXGEN_IMAGE_QUALITY", DEFAULT_JPEG_QUALITY,
+                            1, 100, log)
+    before = after = 0
+    new_images = {}
+    for href, data in images.items():
+        before += len(data)
+        opt = optimize_image(data, max_dim=max_dim, jpeg_quality=quality, log=log)
+        after += len(opt)
+        new_images[href] = opt
+    new_cover = cover_image
+    if cover_image:
+        before += len(cover_image)
+        new_cover = optimize_image(cover_image, max_dim=max_dim,
+                                   jpeg_quality=quality, log=log)
+        after += len(new_cover)
+    if before and after < before:
+        saved = before - after
+        log.info(f"  Image optimization: {before:,} -> {after:,} bytes "
+                 f"(saved {saved:,}, {round(100 * saved / before)}%)")
+    return new_cover, new_images
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_image_optimize.py -v`
+Expected: PASS (all tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugin/kfxgen/image_optimize.py tests/unit/test_image_optimize.py
+git commit -m "feat(images): optimize_images cover+body wrapper with env knobs (#11)"
+```
+
+---
+
+### Task 4: Wire optimization into `convert_oeb_to_kfx`
+
+**Files:**
+- Modify: `plugin/kfxgen/converter.py` (insert after body-image extraction, ~line 923, inside `convert_oeb_to_kfx`)
+- Test: `tests/unit/test_converter.py`
+
+**Interfaces:**
+- Consumes: `optimize_images` (Task 3); `opts.kfxgen_embed_original_images` (Task 5 defines the option; read defensively with `getattr`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/unit/test_converter.py
+import types as _types
+from kfxgen import converter as _conv
+
+
+class _OptsStub:
+    def __init__(self, embed): self.kfxgen_embed_original_images = embed
+
+
+class _Log2:
+    def info(self, *a): pass
+    def warn(self, *a): pass
+    def debug(self, *a): pass
+    def error(self, *a): pass
+
+
+def _patch_pipeline(monkeypatch, captured):
+    monkeypatch.setattr(_conv, "extract_metadata",
+                        lambda *a, **k: {"title": "T", "author": "A",
+                                         "language": "en", "publisher": "P",
+                                         "issue_date": None})
+    monkeypatch.setattr(_conv, "extract_cover_image", lambda *a, **k: (b"COVER", "c.jpg"))
+    monkeypatch.setattr(_conv, "extract_images_from_oeb",
+                        lambda *a, **k: {"x.jpg": b"XX"})
+    monkeypatch.setattr(_conv, "extract_chapters_from_oeb",
+                        lambda *a, **k: [{"text": "hi"}])
+
+    class _Gen:
+        def generate_full_book(self, **kw):
+            captured["images"] = kw["images"]
+            captured["cover"] = kw["cover_image"]
+            # create the output file so the success branch passes
+            with open(kw["output_path"], "wb") as f:
+                f.write(b"KFX")
+    monkeypatch.setattr(_conv, "NativeKFXGenerator", lambda: _Gen())
+
+
+def test_optimization_runs_by_default(monkeypatch, tmp_path):
+    captured = {}
+    _patch_pipeline(monkeypatch, captured)
+    called = {}
+    monkeypatch.setattr(_conv, "optimize_images",
+                        lambda cover, images, log: (called.setdefault("yes", True), (b"C2", {"x.jpg": b"Y"}))[1],
+                        raising=False)
+    out = tmp_path / "o.kfx"
+    _conv.convert_oeb_to_kfx(object(), str(out), _OptsStub(False), _Log2())
+    assert called.get("yes") is True
+    assert captured["cover"] == b"C2"
+    assert captured["images"] == {"x.jpg": b"Y"}
+
+
+def test_optimization_skipped_when_embed_originals(monkeypatch, tmp_path):
+    captured = {}
+    _patch_pipeline(monkeypatch, captured)
+    monkeypatch.setattr(_conv, "optimize_images",
+                        lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not be called")),
+                        raising=False)
+    out = tmp_path / "o.kfx"
+    _conv.convert_oeb_to_kfx(object(), str(out), _OptsStub(True), _Log2())
+    assert captured["images"] == {"x.jpg": b"XX"}  # originals untouched
+    assert captured["cover"] == b"COVER"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_converter.py -k optimization -v`
+Expected: FAIL — `optimize_images` not imported in converter / not called (AttributeError or assertion).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `plugin/kfxgen/converter.py`, inside `convert_oeb_to_kfx`, immediately after the body-image extraction block (the `images = extract_images_from_oeb(...)` call, ~line 923) and before "Extract structured chapters", insert:
+
+```python
+    # Optimize over-size images unless the user opted to embed originals (#11).
+    if getattr(opts, "kfxgen_embed_original_images", False):
+        log.info("  Image optimization disabled (embed original images)")
+    else:
+        cover_image, images = optimize_images(cover_image, images, log)
+```
+
+And add the import near the top of `converter.py` with the other local imports:
+
+```python
+from .image_optimize import optimize_images
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_converter.py -v`
+Expected: PASS (new tests + existing converter tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugin/kfxgen/converter.py tests/unit/test_converter.py
+git commit -m "feat(images): run image optimization in convert_oeb_to_kfx with escape hatch (#11)"
+```
+
+---
+
+### Task 5: Expose the "Embed original images" Calibre option
+
+**Files:**
+- Modify: `plugin/__init__.py` (import + `options` attribute on `KFXGenOutputPlugin`)
+- Test: `tests/unit/test_plugin_options.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: Calibre option `kfxgen_embed_original_images` (default False), surfaced in the GUI and as `--kfxgen-embed-original-images` on the CLI; read by Task 4.
+
+Note: `plugin/__init__.py` imports `calibre.*`, which is unavailable in CI, so the test asserts on the **source text** rather than importing the module.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_plugin_options.py
+from pathlib import Path
+
+SRC = Path("plugin/__init__.py").read_text()
+
+
+def test_imports_option_recommendation():
+    assert "OptionRecommendation" in SRC
+
+
+def test_defines_embed_original_images_option():
+    assert "kfxgen_embed_original_images" in SRC
+    # default must be False (optimization on by default)
+    assert "recommended_value=False" in SRC
+
+
+def test_option_has_help_text():
+    assert "original resolution" in SRC.lower() or "embed" in SRC.lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_plugin_options.py -v`
+Expected: FAIL — `kfxgen_embed_original_images` / `OptionRecommendation` not present.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `plugin/__init__.py`, change the import line:
+
+```python
+from calibre.customize.conversion import OutputFormatPlugin, OptionRecommendation
+```
+
+Add the `options` attribute to `KFXGenOutputPlugin` (alongside `name`, `file_type`, etc.):
+
+```python
+    options = {
+        OptionRecommendation(
+            name="kfxgen_embed_original_images",
+            recommended_value=False,
+            help=(
+                "Embed images at their original resolution instead of "
+                "downscaling/recompressing them for Kindle. Produces much "
+                "larger KFX files for illustrated books."
+            ),
+        ),
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_plugin_options.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add plugin/__init__.py tests/unit/test_plugin_options.py
+git commit -m "feat(images): add 'Embed original images' Calibre option (#11)"
+```
+
+---
+
+### Task 6: Docs + full suite + CHANGELOG
+
+**Files:**
+- Modify: `README.md` (remove/adjust the image-size limitation now that it's addressed; document the option + env knobs)
+- Modify: `CHANGELOG.md` (new version entry)
+- Modify: `plugin/kfxgen/__init__.py` (version bump)
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Run the full suite (no test to add; this is the regression gate)**
+
+Run: `.venv/bin/python -m pytest tests/ -q`
+Expected: PASS, including the golden corpus (golden fixtures use <2048px images, so KFX output is byte-identical — proving no regression for normal books).
+
+- [ ] **Step 2: Update README limitation + document the option**
+
+In `README.md`, replace the image-size limitation bullet (the one linking #11) with a feature/usage note:
+
+```markdown
+- Images larger than 2048 px on the long edge are automatically downscaled and recompressed (JPEG quality 85) so illustrated books stay a reasonable size. To keep originals, enable **Embed original images** in the KFX output options (CLI: `--kfxgen-embed-original-images`). Tune with `KFXGEN_IMAGE_MAX_DIM` and `KFXGEN_IMAGE_QUALITY`.
+```
+
+- [ ] **Step 3: Bump version + CHANGELOG**
+
+In `plugin/kfxgen/__init__.py` bump `version` (e.g. `(5, 3, 19)`). Prepend to `CHANGELOG.md`:
+
+```markdown
+## 5.3.19 — Automatic image optimization
+
+Heavily illustrated books no longer produce huge KFX files. Images whose
+longest edge exceeds 2048 px are downscaled and recompressed (JPEG quality
+85; PNG kept as PNG) during conversion.
+
+- On by default. Disable with the **Embed original images** output option
+  (CLI `--kfxgen-embed-original-images`).
+- Tunable via `KFXGEN_IMAGE_MAX_DIM` and `KFXGEN_IMAGE_QUALITY`.
+- Closes #11.
+```
+
+- [ ] **Step 4: Run the suite once more**
+
+Run: `.venv/bin/python -m pytest tests/ -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md CHANGELOG.md plugin/kfxgen/__init__.py
+git commit -m "docs+release: automatic image optimization, v5.3.19 (#11)"
+```
+
+---
+
+## Notes for the implementer
+
+- The actual `calibre.utils.img.scale_image` resize cannot run in CI (no Calibre). Tests mock it; verify the real downscale on a Calibre install by converting an image-heavy book and confirming the KFX shrinks dramatically (the "What It's Like to Be a Bird" case went 308 MB at full-res).
+- If `scale_image`'s keyword names differ in the target Calibre version, adjust the call in `optimize_image` only — the tests assert on the arguments we pass, so update both together.
+- Do not modify the golden fixtures. Their images are small by design; that they stay byte-identical is the regression guard.

--- a/docs/superpowers/specs/2026-06-27-image-optimization-design.md
+++ b/docs/superpowers/specs/2026-06-27-image-optimization-design.md
@@ -1,0 +1,129 @@
+# Image optimization for KFX output — design
+
+Issue: [#11](https://github.com/jloutsch/kfxgen/issues/11)
+Date: 2026-06-27
+
+## Problem
+
+kfxgen embeds body images and the cover as raw source bytes — no downscaling
+or recompression anywhere in `converter.py` / `native_generator.py`. Heavily
+illustrated books therefore produce enormous KFX files: a real conversion of a
+469-image book (v5.3.18) yielded a 308 MB KFX. That is impractical to sideload
+and store, and some Kindles handle very large KFX poorly.
+
+## Goal
+
+Downscale and recompress over-size images during conversion so image-heavy
+books produce device-friendly KFX, on by default, with an escape hatch to keep
+originals. Bounded to what KFX/Kindle actually need; no attempt to support
+arbitrary image pipelines.
+
+## Scope
+
+In scope (this change):
+- The **Calibre plugin path** only. It runs inside Calibre, so
+  `calibre.utils.img` is available — no new dependency.
+- Body images and the cover image.
+
+Out of scope (deferred, noted in the issue):
+- The direct-Python research path (`research/`), which would need Pillow.
+- Converting opaque PNG → JPEG.
+- Re-encoding images that are already within the dimension limit.
+
+## Decisions
+
+| Decision | Choice |
+|---|---|
+| Default behavior | **On by default**, with an escape hatch to embed originals. |
+| Trigger | **Dimension-only.** Act on an image when its longest edge exceeds `max_dim`. Images at or under the limit are passed through untouched (no quality loss). |
+| Max long edge (`max_dim`) | **2048 px** default. |
+| JPEG quality | **85** default. |
+| Format handling | JPEG over the limit → downscale + re-encode JPEG at quality. PNG over the limit → downscale, keep PNG (preserves transparency / line art). |
+| Escape hatch | Calibre GUI checkbox **"Embed original images"** (`OptionRecommendation`, default `False`), read from `opts`. |
+| Numeric knobs | Env vars `KFXGEN_IMAGE_MAX_DIM` (default 2048) and `KFXGEN_IMAGE_QUALITY` (default 85), validated like `KFXGEN_MAX_DECODE_SIZE` (positive int, sane bounds, fall back to default on invalid). |
+
+## Architecture
+
+New module `plugin/kfxgen/image_optimize.py`:
+
+- `_read_image_size(data: bytes) -> tuple[int, int] | None`
+  Pure-Python JPEG/PNG header parse to get `(width, height)`. No Calibre
+  dependency, so it is fully unit-testable in CI. Returns `None` if the size
+  can't be determined (caller then leaves the image untouched).
+
+- `optimize_image(data: bytes, *, max_dim: int = 2048, jpeg_quality: int = 85, log) -> bytes`
+  1. Read size via `_read_image_size`. If unknown or longest edge ≤ `max_dim`,
+     return `data` unchanged.
+  2. Otherwise compute the target size (scale longest edge to `max_dim`,
+     preserve aspect ratio), then **lazy-import** `calibre.utils.img` and use it
+     to decode → scale → re-encode (JPEG at `jpeg_quality`; PNG stays PNG).
+  3. If `calibre.utils.img` is unavailable (e.g. CI / non-Calibre runtime) or
+     any step raises, log and **return the original bytes** — never fail the
+     conversion. Also return the original if the "optimized" result is somehow
+     larger than the input.
+
+Integration point: a distinct stage in `convert_oeb_to_kfx` (`converter.py`).
+After body images and the cover are extracted (and magic-byte validated as
+today), map `optimize_image` over the body-image dict values and the cover
+bytes, unless the escape hatch is set. The existing extractor functions
+(`extract_inline_images`, `extract_cover_image`, `_get_cover_image_data`) stay
+pure and unchanged — optimization is a separate, testable step.
+
+The plugin wrapper (`plugin/__init__.py`) gains:
+```python
+from calibre.customize.conversion import OutputFormatPlugin, OptionRecommendation
+...
+options = {
+    OptionRecommendation(
+        name='kfxgen_embed_original_images',
+        recommended_value=False,
+        help='Embed images at their original resolution instead of '
+             'downscaling/recompressing them for Kindle. Produces much '
+             'larger KFX files for illustrated books.'),
+}
+```
+The value arrives as `opts.kfxgen_embed_original_images`; the converter reads it
+with `getattr(opts, 'kfxgen_embed_original_images', False)` so non-Calibre
+callers and tests work without the attribute.
+
+## Error handling
+
+- Decode/scale/encode failure → warn, keep original bytes.
+- `calibre.utils.img` missing → debug log, keep original bytes (no-op).
+- Invalid env-var values → warn, use defaults.
+- Magic-byte validation (#46) remains upstream, unchanged. Optimization only
+  ever sees already-validated JPEG/PNG bytes.
+
+## Testing (TDD)
+
+Unit (`tests/unit/test_image_optimize.py`), all CI-runnable without Calibre:
+- `_read_image_size`: correct dimensions for known JPEG and PNG fixtures;
+  `None` for truncated/garbage input.
+- `optimize_image` decision logic:
+  - image ≤ `max_dim` → returned unchanged (identity).
+  - `calibre.utils.img` unavailable → returned unchanged (monkeypatch the
+    import to fail), no exception.
+  - over `max_dim` with `calibre.utils.img` mocked → scale called with the
+    expected target dimensions; format preserved (JPEG stays JPEG, PNG stays
+    PNG); JPEG path passes `jpeg_quality`.
+  - env-var overrides parsed and clamped like `MAX_DECODE_SIZE`.
+- Escape hatch: `convert_oeb_to_kfx` skips optimization when
+  `opts.kfxgen_embed_original_images` is true (verified via a spy/mock on
+  `optimize_image`).
+
+Golden/regression:
+- Existing golden KFX fixtures use tiny (<2048) synthetic images, so they remain
+  **byte-identical** — no golden regression.
+- Add a synthetic oversized image (longest edge > 2048) and assert the optimized
+  output is smaller and within the limit. Where actual scaling needs Calibre,
+  drive it through the mock; otherwise assert the no-op path.
+
+## Acceptance criteria
+
+- A book whose images exceed 2048 px produces a KFX dramatically smaller than
+  today, at default settings, with no conversion failure.
+- The "Embed original images" checkbox (GUI), or its Calibre CLI equivalent
+  `--kfxgen-embed-original-images`, restores the current full-resolution
+  behavior.
+- `KFXGEN_IMAGE_MAX_DIM` / `KFXGEN_IMAGE_QUALITY` change the limits.
+- All existing tests still pass; golden fixtures unchanged.

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -14,7 +14,7 @@ __license__ = "GPL v3"
 __copyright__ = "2025-2026, Justin Loutsch <justin.loutsch@gmail.com>"
 __docformat__ = "restructuredtext en"
 
-from calibre.customize.conversion import OutputFormatPlugin
+from calibre.customize.conversion import OutputFormatPlugin, OptionRecommendation
 
 # Single source of truth for the package version lives in
 # plugin/kfxgen/__init__.py — read it here so the wrapper and the inner
@@ -46,6 +46,18 @@ class KFXGenOutputPlugin(OutputFormatPlugin):
     commit_name = "kfxgen"
     minimum_calibre_version = (5, 0, 0)
     can_be_disabled = True
+
+    options = {
+        OptionRecommendation(
+            name="kfxgen_embed_original_images",
+            recommended_value=False,
+            help=(
+                "Embed images at their original resolution instead of "
+                "downscaling/recompressing them for Kindle. Produces much "
+                "larger KFX files for illustrated books."
+            ),
+        ),
+    }
 
     def convert(self, oeb_book, output_path, input_plugin, opts, log):
         """

--- a/plugin/kfxgen/__init__.py
+++ b/plugin/kfxgen/__init__.py
@@ -12,7 +12,7 @@ __copyright__ = "2025-2026, Justin Loutsch <justin.loutsch@gmail.com>"
 
 #: Version tuple. Bump this for every release; the plugin wrapper and
 #: converter log message read from here.
-version = (5, 3, 18)
+version = (5, 3, 19)
 __version__ = ".".join(str(x) for x in version)
 
 __all__ = [

--- a/plugin/kfxgen/__init__.py
+++ b/plugin/kfxgen/__init__.py
@@ -12,7 +12,7 @@ __copyright__ = "2025-2026, Justin Loutsch <justin.loutsch@gmail.com>"
 
 #: Version tuple. Bump this for every release; the plugin wrapper and
 #: converter log message read from here.
-version = (5, 3, 19)
+version = (5, 3, 20)
 __version__ = ".".join(str(x) for x in version)
 
 __all__ = [

--- a/plugin/kfxgen/converter.py
+++ b/plugin/kfxgen/converter.py
@@ -15,6 +15,7 @@ from ._img_tokens import (
     IMG_TOKEN_RE as _IMG_TOKEN_RE,
     IMG_TOKEN_SPACE as _IMG_TOKEN_SPACE,
 )
+from .image_optimize import optimize_images
 from .native_generator import NativeKFXGenerator
 
 _security_log = logging.getLogger(__name__ + ".security")
@@ -921,6 +922,12 @@ def convert_oeb_to_kfx(oeb_book, output_path, opts, log):
     images = extract_images_from_oeb(
         oeb_book, log, exclude_hrefs=[cover_href] if cover_href else []
     )
+
+    # Optimize over-size images unless the user opted to embed originals (#11).
+    if getattr(opts, "kfxgen_embed_original_images", False):
+        log.info("  Image optimization disabled (embed original images)")
+    else:
+        cover_image, images = optimize_images(cover_image, images, log)
 
     # Extract structured chapters
     log.info("Extracting chapters...")

--- a/plugin/kfxgen/image_optimize.py
+++ b/plugin/kfxgen/image_optimize.py
@@ -1,0 +1,65 @@
+"""Image optimization for KFX output (#11).
+
+Downscales and recompresses over-size images so heavily illustrated books
+produce device-friendly KFX. On by default in the conversion path. The actual
+resize uses calibre.utils.img at runtime; outside Calibre (tests/CI) it is a
+no-op so it never breaks anything.
+"""
+
+import os
+import struct
+
+DEFAULT_MAX_DIM = 2048
+DEFAULT_JPEG_QUALITY = 85
+
+_PNG_SIG = b"\x89PNG\r\n\x1a\n"
+# JPEG Start-Of-Frame markers that carry image dimensions.
+_SOF_MARKERS = {0xC0, 0xC1, 0xC2, 0xC3, 0xC5, 0xC6, 0xC7,
+                0xC9, 0xCA, 0xCB, 0xCD, 0xCE, 0xCF}
+
+
+def _read_image_size(data):
+    """Return (width, height) for PNG or JPEG bytes, else None."""
+    if len(data) >= 24 and data[:8] == _PNG_SIG:
+        w, h = struct.unpack(">II", data[16:24])
+        return (int(w), int(h))
+    if data[:2] == b"\xff\xd8":  # JPEG SOI
+        i, n = 2, len(data)
+        while i + 1 < n:
+            if data[i] != 0xFF:
+                i += 1
+                continue
+            marker = data[i + 1]
+            if marker == 0xFF:
+                i += 1
+                continue
+            if marker in (0xD8, 0xD9) or 0xD0 <= marker <= 0xD7:
+                i += 2
+                continue
+            if i + 4 > n:
+                break
+            seg_len = struct.unpack(">H", data[i + 2:i + 4])[0]
+            if marker in _SOF_MARKERS:
+                if i + 9 <= n:
+                    h, w = struct.unpack(">HH", data[i + 5:i + 9])
+                    return (int(w), int(h))
+                break
+            i += 2 + seg_len
+        return None
+    return None
+
+
+def _read_env_int(name, default, lo, hi, log):
+    """Read an int env var, falling back to default on missing/invalid/range."""
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        n = int(raw)
+    except (TypeError, ValueError):
+        log.warn(f"  ignoring invalid {name}={raw!r} (not an integer); using {default}")
+        return default
+    if n < lo or n > hi:
+        log.warn(f"  ignoring out-of-range {name}={n} (allowed {lo}-{hi}); using {default}")
+        return default
+    return n

--- a/plugin/kfxgen/image_optimize.py
+++ b/plugin/kfxgen/image_optimize.py
@@ -63,3 +63,37 @@ def _read_env_int(name, default, lo, hi, log):
         log.warn(f"  ignoring out-of-range {name}={n} (allowed {lo}-{hi}); using {default}")
         return default
     return n
+
+
+def optimize_image(data, *, max_dim=DEFAULT_MAX_DIM, jpeg_quality=DEFAULT_JPEG_QUALITY, log=None):
+    """Downscale + recompress an over-size JPEG/PNG.
+
+    Returns optimized bytes, or the original bytes unchanged when no
+    optimization applies, calibre is unavailable, or anything fails.
+    Never raises.
+    """
+    size = _read_image_size(data)
+    if size is None:
+        return data
+    if max(size) <= max_dim:
+        return data
+    is_png = data[:8] == _PNG_SIG
+    try:
+        from calibre.utils.img import scale_image
+    except Exception:
+        if log:
+            log.debug("  calibre.utils.img unavailable; leaving image at original size")
+        return data
+    try:
+        # scale_image fits within the (width, height) box, preserving aspect.
+        _fmt, out = scale_image(
+            data, width=max_dim, height=max_dim,
+            as_png=is_png, compression_quality=jpeg_quality,
+        )
+    except Exception as e:  # noqa: BLE001 - never fail a conversion over an image
+        if log:
+            log.warn(f"  image optimize failed ({e}); keeping original")
+        return data
+    if not out or len(out) >= len(data):
+        return data
+    return out

--- a/plugin/kfxgen/image_optimize.py
+++ b/plugin/kfxgen/image_optimize.py
@@ -85,8 +85,12 @@ def optimize_image(data, *, max_dim=DEFAULT_MAX_DIM, jpeg_quality=DEFAULT_JPEG_Q
             log.debug("  calibre.utils.img unavailable; leaving image at original size")
         return data
     try:
-        # scale_image fits within the (width, height) box, preserving aspect.
-        _fmt, out = scale_image(
+        # scale_image fits within the (width, height) box, preserving aspect,
+        # and returns (scaled_width, scaled_height, data) — a 3-tuple, not the
+        # (fmt, data) pair an earlier version assumed. Unpacking it as 2 values
+        # raised ValueError on every real call, so optimization silently fell
+        # back to the original bytes for every image (#11).
+        _w, _h, out = scale_image(
             data, width=max_dim, height=max_dim,
             as_png=is_png, compression_quality=jpeg_quality,
         )

--- a/plugin/kfxgen/image_optimize.py
+++ b/plugin/kfxgen/image_optimize.py
@@ -97,3 +97,32 @@ def optimize_image(data, *, max_dim=DEFAULT_MAX_DIM, jpeg_quality=DEFAULT_JPEG_Q
     if not out or len(out) >= len(data):
         return data
     return out
+
+
+_MIN_MAX_DIM, _MAX_MAX_DIM = 16, 20000
+
+
+def optimize_images(cover_image, images, log):
+    """Optimize the cover and every body image. Returns (cover, images)."""
+    max_dim = _read_env_int("KFXGEN_IMAGE_MAX_DIM", DEFAULT_MAX_DIM,
+                            _MIN_MAX_DIM, _MAX_MAX_DIM, log)
+    quality = _read_env_int("KFXGEN_IMAGE_QUALITY", DEFAULT_JPEG_QUALITY,
+                            1, 100, log)
+    before = after = 0
+    new_images = {}
+    for href, data in images.items():
+        before += len(data)
+        opt = optimize_image(data, max_dim=max_dim, jpeg_quality=quality, log=log)
+        after += len(opt)
+        new_images[href] = opt
+    new_cover = cover_image
+    if cover_image:
+        before += len(cover_image)
+        new_cover = optimize_image(cover_image, max_dim=max_dim,
+                                   jpeg_quality=quality, log=log)
+        after += len(new_cover)
+    if before and after < before:
+        saved = before - after
+        log.info(f"  Image optimization: {before:,} -> {after:,} bytes "
+                 f"(saved {saved:,}, {round(100 * saved / before)}%)")
+    return new_cover, new_images

--- a/tests/unit/test_converter.py
+++ b/tests/unit/test_converter.py
@@ -384,3 +384,68 @@ class TestHalfTitlePage:
         # DRY union so a future edit can't desync them (#107).
         assert HALF_TITLE_TITLES <= CONTENTS_SKIP_TITLES
         assert TITLE_PAGE_TITLES <= CONTENTS_SKIP_TITLES
+
+
+import types as _types
+import pytest
+from kfxgen import converter as _conv
+
+
+class _OptsStub:
+    def __init__(self, embed): self.kfxgen_embed_original_images = embed
+
+
+class _Log2:
+    def info(self, *a): pass
+    def warn(self, *a): pass
+    def debug(self, *a): pass
+    def error(self, *a): pass
+
+
+def _patch_pipeline(monkeypatch, captured):
+    monkeypatch.setattr(_conv, "extract_metadata",
+                        lambda *a, **k: {"title": "T", "author": "A",
+                                         "language": "en", "publisher": "P",
+                                         "issue_date": None})
+    monkeypatch.setattr(_conv, "extract_cover_image", lambda *a, **k: (b"COVER", "c.jpg"))
+    monkeypatch.setattr(_conv, "extract_images_from_oeb",
+                        lambda *a, **k: {"x.jpg": b"XX"})
+    monkeypatch.setattr(_conv, "extract_chapters_from_oeb",
+                        lambda *a, **k: [{"text": "hi"}])
+
+    class _Gen:
+        def generate_full_book(self, **kw):
+            captured["images"] = kw["images"]
+            captured["cover"] = kw["cover_image"]
+            # create the output file so the success branch passes
+            with open(kw["output_path"], "wb") as f:
+                f.write(b"KFX")
+    monkeypatch.setattr(_conv, "NativeKFXGenerator", lambda: _Gen())
+
+
+@pytest.mark.unit
+def test_optimization_runs_by_default(monkeypatch, tmp_path):
+    captured = {}
+    _patch_pipeline(monkeypatch, captured)
+    called = {}
+    monkeypatch.setattr(_conv, "optimize_images",
+                        lambda cover, images, log: (called.setdefault("yes", True), (b"C2", {"x.jpg": b"Y"}))[1],
+                        raising=False)
+    out = tmp_path / "o.kfx"
+    _conv.convert_oeb_to_kfx(object(), str(out), _OptsStub(False), _Log2())
+    assert called.get("yes") is True
+    assert captured["cover"] == b"C2"
+    assert captured["images"] == {"x.jpg": b"Y"}
+
+
+@pytest.mark.unit
+def test_optimization_skipped_when_embed_originals(monkeypatch, tmp_path):
+    captured = {}
+    _patch_pipeline(monkeypatch, captured)
+    monkeypatch.setattr(_conv, "optimize_images",
+                        lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not be called")),
+                        raising=False)
+    out = tmp_path / "o.kfx"
+    _conv.convert_oeb_to_kfx(object(), str(out), _OptsStub(True), _Log2())
+    assert captured["images"] == {"x.jpg": b"XX"}  # originals untouched
+    assert captured["cover"] == b"COVER"

--- a/tests/unit/test_converter.py
+++ b/tests/unit/test_converter.py
@@ -9,10 +9,12 @@ import os
 import sys
 from unittest.mock import MagicMock
 
+import pytest
 from lxml import etree
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "plugin"))
 
+from kfxgen import converter as _conv
 from kfxgen.converter import (
     CONTENTS_SKIP_TITLES,
     HALF_TITLE_TITLES,
@@ -384,11 +386,6 @@ class TestHalfTitlePage:
         # DRY union so a future edit can't desync them (#107).
         assert HALF_TITLE_TITLES <= CONTENTS_SKIP_TITLES
         assert TITLE_PAGE_TITLES <= CONTENTS_SKIP_TITLES
-
-
-import types as _types
-import pytest
-from kfxgen import converter as _conv
 
 
 class _OptsStub:

--- a/tests/unit/test_image_optimize.py
+++ b/tests/unit/test_image_optimize.py
@@ -22,29 +22,35 @@ class _Log:
     def debug(self, m): pass
 
 
+@pytest.mark.unit
 def test_read_size_png():
     assert io._read_image_size(_png(3000, 2000)) == (3000, 2000)
 
 
+@pytest.mark.unit
 def test_read_size_jpeg():
     assert io._read_image_size(_jpeg(2500, 1800)) == (2500, 1800)
 
 
+@pytest.mark.unit
 def test_read_size_unknown_returns_none():
     assert io._read_image_size(b"not an image") is None
     assert io._read_image_size(b"\xff\xd8short") is None
 
 
+@pytest.mark.unit
 def test_env_int_default_when_unset(monkeypatch):
     monkeypatch.delenv("KFXGEN_IMAGE_MAX_DIM", raising=False)
     assert io._read_env_int("KFXGEN_IMAGE_MAX_DIM", 2048, 16, 20000, _Log()) == 2048
 
 
+@pytest.mark.unit
 def test_env_int_valid(monkeypatch):
     monkeypatch.setenv("KFXGEN_IMAGE_MAX_DIM", "1600")
     assert io._read_env_int("KFXGEN_IMAGE_MAX_DIM", 2048, 16, 20000, _Log()) == 1600
 
 
+@pytest.mark.unit
 def test_env_int_invalid_falls_back(monkeypatch):
     monkeypatch.setenv("KFXGEN_IMAGE_MAX_DIM", "huge")
     log = _Log()
@@ -52,6 +58,9 @@ def test_env_int_invalid_falls_back(monkeypatch):
     assert log.warns
 
 
+@pytest.mark.unit
 def test_env_int_out_of_range_falls_back(monkeypatch):
     monkeypatch.setenv("KFXGEN_IMAGE_QUALITY", "999")
-    assert io._read_env_int("KFXGEN_IMAGE_QUALITY", 85, 1, 100, _Log()) == 85
+    log = _Log()
+    assert io._read_env_int("KFXGEN_IMAGE_QUALITY", 85, 1, 100, log) == 85
+    assert log.warns

--- a/tests/unit/test_image_optimize.py
+++ b/tests/unit/test_image_optimize.py
@@ -1,0 +1,57 @@
+import struct
+import pytest
+from kfxgen import image_optimize as io
+
+
+def _png(w, h):
+    return (b"\x89PNG\r\n\x1a\n" + struct.pack(">I", 13) + b"IHDR"
+            + struct.pack(">II", w, h) + b"\x08\x02\x00\x00\x00")
+
+
+def _jpeg(w, h):
+    # SOI, APP0 stub, SOF0 (len=17, precision=8, height, width), EOI
+    app0 = b"\xff\xe0" + struct.pack(">H", 16) + b"JFIF\x00" + b"\x01\x01\x00" + b"\x00\x01\x00\x01\x00\x00"
+    sof0 = b"\xff\xc0" + struct.pack(">H", 17) + b"\x08" + struct.pack(">HH", h, w) + b"\x03\x01\x22\x00\x02\x11\x01\x03\x11\x01"
+    return b"\xff\xd8" + app0 + sof0 + b"\xff\xd9"
+
+
+class _Log:
+    def __init__(self): self.warns = []
+    def warn(self, m): self.warns.append(m)
+    def info(self, m): pass
+    def debug(self, m): pass
+
+
+def test_read_size_png():
+    assert io._read_image_size(_png(3000, 2000)) == (3000, 2000)
+
+
+def test_read_size_jpeg():
+    assert io._read_image_size(_jpeg(2500, 1800)) == (2500, 1800)
+
+
+def test_read_size_unknown_returns_none():
+    assert io._read_image_size(b"not an image") is None
+    assert io._read_image_size(b"\xff\xd8short") is None
+
+
+def test_env_int_default_when_unset(monkeypatch):
+    monkeypatch.delenv("KFXGEN_IMAGE_MAX_DIM", raising=False)
+    assert io._read_env_int("KFXGEN_IMAGE_MAX_DIM", 2048, 16, 20000, _Log()) == 2048
+
+
+def test_env_int_valid(monkeypatch):
+    monkeypatch.setenv("KFXGEN_IMAGE_MAX_DIM", "1600")
+    assert io._read_env_int("KFXGEN_IMAGE_MAX_DIM", 2048, 16, 20000, _Log()) == 1600
+
+
+def test_env_int_invalid_falls_back(monkeypatch):
+    monkeypatch.setenv("KFXGEN_IMAGE_MAX_DIM", "huge")
+    log = _Log()
+    assert io._read_env_int("KFXGEN_IMAGE_MAX_DIM", 2048, 16, 20000, log) == 2048
+    assert log.warns
+
+
+def test_env_int_out_of_range_falls_back(monkeypatch):
+    monkeypatch.setenv("KFXGEN_IMAGE_QUALITY", "999")
+    assert io._read_env_int("KFXGEN_IMAGE_QUALITY", 85, 1, 100, _Log()) == 85

--- a/tests/unit/test_image_optimize.py
+++ b/tests/unit/test_image_optimize.py
@@ -130,3 +130,38 @@ def test_optimize_image_keeps_original_if_result_larger(monkeypatch):
 
     big = _jpeg(4000, 3000)
     assert io.optimize_image(big, max_dim=2048, log=_Log()) == big
+
+
+@pytest.mark.unit
+def test_optimize_images_maps_all_and_handles_none_cover(monkeypatch):
+    # Force the per-image optimizer to a deterministic stub.
+    monkeypatch.setattr(io, "optimize_image",
+                        lambda data, **k: b"OPT" + data[:1])
+    cover, imgs = io.optimize_images(None, {"a.jpg": b"AAAA", "b.png": b"BBBB"}, _Log())
+    assert cover is None
+    assert imgs == {"a.jpg": b"OPTA", "b.png": b"OPTB"}
+
+
+@pytest.mark.unit
+def test_optimize_images_optimizes_cover(monkeypatch):
+    monkeypatch.setattr(io, "optimize_image", lambda data, **k: b"C")
+    cover, imgs = io.optimize_images(b"COVERDATA", {}, _Log())
+    assert cover == b"C"
+    assert imgs == {}
+
+
+@pytest.mark.unit
+def test_optimize_images_reads_env_overrides(monkeypatch):
+    seen = {}
+    monkeypatch.setenv("KFXGEN_IMAGE_MAX_DIM", "1600")
+    monkeypatch.setenv("KFXGEN_IMAGE_QUALITY", "70")
+
+    def spy(data, *, max_dim, jpeg_quality, log):
+        seen["max_dim"] = max_dim
+        seen["q"] = jpeg_quality
+        return data
+
+    monkeypatch.setattr(io, "optimize_image", spy)
+    io.optimize_images(b"COVER", {"a.jpg": b"AAAA"}, _Log())
+    assert seen["max_dim"] == 1600
+    assert seen["q"] == 70

--- a/tests/unit/test_image_optimize.py
+++ b/tests/unit/test_image_optimize.py
@@ -88,7 +88,8 @@ def test_optimize_image_downscales_via_calibre(monkeypatch):
 
     def scale_image(data, width, height, as_png=False, compression_quality=90):
         calls["args"] = (width, height, as_png, compression_quality)
-        return ("JPEG", b"small-bytes")
+        # calibre.utils.img.scale_image returns (width, height, data) (#11).
+        return (2048, 1536, b"small-bytes")
 
     fake.scale_image = scale_image
     monkeypatch.setitem(sys.modules, "calibre", types.ModuleType("calibre"))
@@ -108,7 +109,7 @@ def test_optimize_image_keeps_png_format(monkeypatch):
 
     def scale_image(data, width, height, as_png=False, compression_quality=90):
         seen["as_png"] = as_png
-        return ("PNG", b"x" * 10)
+        return (2048, 1536, b"x" * 10)
 
     fake.scale_image = scale_image
     monkeypatch.setitem(sys.modules, "calibre", types.ModuleType("calibre"))
@@ -123,7 +124,7 @@ def test_optimize_image_keeps_png_format(monkeypatch):
 @pytest.mark.unit
 def test_optimize_image_keeps_original_if_result_larger(monkeypatch):
     fake = types.ModuleType("calibre.utils.img")
-    fake.scale_image = lambda *a, **k: ("JPEG", b"Z" * 100000)
+    fake.scale_image = lambda *a, **k: (2048, 1536, b"Z" * 100000)
     monkeypatch.setitem(sys.modules, "calibre", types.ModuleType("calibre"))
     monkeypatch.setitem(sys.modules, "calibre.utils", types.ModuleType("calibre.utils"))
     monkeypatch.setitem(sys.modules, "calibre.utils.img", fake)

--- a/tests/unit/test_image_optimize.py
+++ b/tests/unit/test_image_optimize.py
@@ -1,4 +1,6 @@
 import struct
+import sys
+import types
 import pytest
 from kfxgen import image_optimize as io
 
@@ -64,3 +66,67 @@ def test_env_int_out_of_range_falls_back(monkeypatch):
     log = _Log()
     assert io._read_env_int("KFXGEN_IMAGE_QUALITY", 85, 1, 100, log) == 85
     assert log.warns
+
+
+@pytest.mark.unit
+def test_optimize_image_small_is_identity():
+    data = _jpeg(800, 600)
+    assert io.optimize_image(data, max_dim=2048, log=_Log()) is data
+
+
+@pytest.mark.unit
+def test_optimize_image_no_calibre_is_noop():
+    # calibre.utils.img is absent in CI -> over-size image returns unchanged
+    big = _jpeg(4000, 3000)
+    assert io.optimize_image(big, max_dim=2048, log=_Log()) == big
+
+
+@pytest.mark.unit
+def test_optimize_image_downscales_via_calibre(monkeypatch):
+    calls = {}
+    fake = types.ModuleType("calibre.utils.img")
+
+    def scale_image(data, width, height, as_png=False, compression_quality=90):
+        calls["args"] = (width, height, as_png, compression_quality)
+        return ("JPEG", b"small-bytes")
+
+    fake.scale_image = scale_image
+    monkeypatch.setitem(sys.modules, "calibre", types.ModuleType("calibre"))
+    monkeypatch.setitem(sys.modules, "calibre.utils", types.ModuleType("calibre.utils"))
+    monkeypatch.setitem(sys.modules, "calibre.utils.img", fake)
+
+    big = _jpeg(4000, 3000)
+    out = io.optimize_image(big, max_dim=2048, jpeg_quality=85, log=_Log())
+    assert out == b"small-bytes"
+    assert calls["args"] == (2048, 2048, False, 85)
+
+
+@pytest.mark.unit
+def test_optimize_image_keeps_png_format(monkeypatch):
+    seen = {}
+    fake = types.ModuleType("calibre.utils.img")
+
+    def scale_image(data, width, height, as_png=False, compression_quality=90):
+        seen["as_png"] = as_png
+        return ("PNG", b"x" * 10)
+
+    fake.scale_image = scale_image
+    monkeypatch.setitem(sys.modules, "calibre", types.ModuleType("calibre"))
+    monkeypatch.setitem(sys.modules, "calibre.utils", types.ModuleType("calibre.utils"))
+    monkeypatch.setitem(sys.modules, "calibre.utils.img", fake)
+
+    out = io.optimize_image(_png(4000, 3000), max_dim=2048, log=_Log())
+    assert seen["as_png"] is True
+    assert out == b"x" * 10
+
+
+@pytest.mark.unit
+def test_optimize_image_keeps_original_if_result_larger(monkeypatch):
+    fake = types.ModuleType("calibre.utils.img")
+    fake.scale_image = lambda *a, **k: ("JPEG", b"Z" * 100000)
+    monkeypatch.setitem(sys.modules, "calibre", types.ModuleType("calibre"))
+    monkeypatch.setitem(sys.modules, "calibre.utils", types.ModuleType("calibre.utils"))
+    monkeypatch.setitem(sys.modules, "calibre.utils.img", fake)
+
+    big = _jpeg(4000, 3000)
+    assert io.optimize_image(big, max_dim=2048, log=_Log()) == big

--- a/tests/unit/test_plugin_options.py
+++ b/tests/unit/test_plugin_options.py
@@ -1,0 +1,21 @@
+import pytest
+from pathlib import Path
+
+SRC = Path("plugin/__init__.py").read_text()
+
+
+@pytest.mark.unit
+def test_imports_option_recommendation():
+    assert "OptionRecommendation" in SRC
+
+
+@pytest.mark.unit
+def test_defines_embed_original_images_option():
+    assert "kfxgen_embed_original_images" in SRC
+    # default must be False (optimization on by default)
+    assert "recommended_value=False" in SRC
+
+
+@pytest.mark.unit
+def test_option_has_help_text():
+    assert "original resolution" in SRC.lower() or "embed" in SRC.lower()


### PR DESCRIPTION
## What

Adds automatic image optimization to the KFX conversion path so heavily illustrated books stop producing oversized KFX files. Closes #11.

Images whose longest edge exceeds 2048 px are downscaled and recompressed (JPEG quality 85; PNG kept as PNG) during conversion.

- On by default. Disable with the **Embed original images** output option (CLI `--kfxgen-embed-original-images`).
- Tunable via `KFXGEN_IMAGE_MAX_DIM` and `KFXGEN_IMAGE_QUALITY`.
- No-op fallback outside Calibre (tests/CI), so it never breaks a build.

## The fix in this branch (5.3.20)

The feature as first shipped (5.3.19) was a silent no-op: `calibre.utils.img.scale_image` returns a 3-tuple `(width, height, data)`, but `optimize_image` unpacked it as a 2-tuple, raising `ValueError` on every image. The broad `except` swallowed it and each image kept its original size. The unit-test mocks returned a 2-tuple too, so the bug passed CI.

5.3.20 unpacks the real 3-tuple and corrects the mocks (verified against the real return signature at runtime on Calibre 9.10.0).

## Verification

- 350 unit tests pass; ruff clean.
- End-to-end against a real book ("What It's Like to Be a Bird"): **308 MB → 227 MB** (26% off images, 81 MB saved), with the `Image optimization: ... bytes` line now present in the conversion log and no `image optimize failed` warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)