### PR TITLE
style: ruff format image optimization files (fix CI)

### DIFF
--- a/plugin/kfxgen/image_optimize.py
+++ b/plugin/kfxgen/image_optimize.py
@@ -14,8 +14,21 @@ DEFAULT_JPEG_QUALITY = 85
 
 _PNG_SIG = b"\x89PNG\r\n\x1a\n"
 # JPEG Start-Of-Frame markers that carry image dimensions.
-_SOF_MARKERS = {0xC0, 0xC1, 0xC2, 0xC3, 0xC5, 0xC6, 0xC7,
-                0xC9, 0xCA, 0xCB, 0xCD, 0xCE, 0xCF}
+_SOF_MARKERS = {
+    0xC0,
+    0xC1,
+    0xC2,
+    0xC3,
+    0xC5,
+    0xC6,
+    0xC7,
+    0xC9,
+    0xCA,
+    0xCB,
+    0xCD,
+    0xCE,
+    0xCF,
+}
 
 
 def _read_image_size(data):
@@ -38,10 +51,10 @@ def _read_image_size(data):
                 continue
             if i + 4 > n:
                 break
-            seg_len = struct.unpack(">H", data[i + 2:i + 4])[0]
+            seg_len = struct.unpack(">H", data[i + 2 : i + 4])[0]
             if marker in _SOF_MARKERS:
                 if i + 9 <= n:
-                    h, w = struct.unpack(">HH", data[i + 5:i + 9])
+                    h, w = struct.unpack(">HH", data[i + 5 : i + 9])
                     return (int(w), int(h))
                 break
             i += 2 + seg_len
@@ -60,12 +73,16 @@ def _read_env_int(name, default, lo, hi, log):
         log.warn(f"  ignoring invalid {name}={raw!r} (not an integer); using {default}")
         return default
     if n < lo or n > hi:
-        log.warn(f"  ignoring out-of-range {name}={n} (allowed {lo}-{hi}); using {default}")
+        log.warn(
+            f"  ignoring out-of-range {name}={n} (allowed {lo}-{hi}); using {default}"
+        )
         return default
     return n
 
 
-def optimize_image(data, *, max_dim=DEFAULT_MAX_DIM, jpeg_quality=DEFAULT_JPEG_QUALITY, log=None):
+def optimize_image(
+    data, *, max_dim=DEFAULT_MAX_DIM, jpeg_quality=DEFAULT_JPEG_QUALITY, log=None
+):
     """Downscale + recompress an over-size JPEG/PNG.
 
     Returns optimized bytes, or the original bytes unchanged when no
@@ -91,8 +108,11 @@ def optimize_image(data, *, max_dim=DEFAULT_MAX_DIM, jpeg_quality=DEFAULT_JPEG_Q
         # raised ValueError on every real call, so optimization silently fell
         # back to the original bytes for every image (#11).
         _w, _h, out = scale_image(
-            data, width=max_dim, height=max_dim,
-            as_png=is_png, compression_quality=jpeg_quality,
+            data,
+            width=max_dim,
+            height=max_dim,
+            as_png=is_png,
+            compression_quality=jpeg_quality,
         )
     except Exception as e:  # noqa: BLE001 - never fail a conversion over an image
         if log:
@@ -108,10 +128,10 @@ _MIN_MAX_DIM, _MAX_MAX_DIM = 16, 20000
 
 def optimize_images(cover_image, images, log):
     """Optimize the cover and every body image. Returns (cover, images)."""
-    max_dim = _read_env_int("KFXGEN_IMAGE_MAX_DIM", DEFAULT_MAX_DIM,
-                            _MIN_MAX_DIM, _MAX_MAX_DIM, log)
-    quality = _read_env_int("KFXGEN_IMAGE_QUALITY", DEFAULT_JPEG_QUALITY,
-                            1, 100, log)
+    max_dim = _read_env_int(
+        "KFXGEN_IMAGE_MAX_DIM", DEFAULT_MAX_DIM, _MIN_MAX_DIM, _MAX_MAX_DIM, log
+    )
+    quality = _read_env_int("KFXGEN_IMAGE_QUALITY", DEFAULT_JPEG_QUALITY, 1, 100, log)
     before = after = 0
     new_images = {}
     for href, data in images.items():
@@ -122,11 +142,14 @@ def optimize_images(cover_image, images, log):
     new_cover = cover_image
     if cover_image:
         before += len(cover_image)
-        new_cover = optimize_image(cover_image, max_dim=max_dim,
-                                   jpeg_quality=quality, log=log)
+        new_cover = optimize_image(
+            cover_image, max_dim=max_dim, jpeg_quality=quality, log=log
+        )
         after += len(new_cover)
     if before and after < before:
         saved = before - after
-        log.info(f"  Image optimization: {before:,} -> {after:,} bytes "
-                 f"(saved {saved:,}, {round(100 * saved / before)}%)")
+        log.info(
+            f"  Image optimization: {before:,} -> {after:,} bytes "
+            f"(saved {saved:,}, {round(100 * saved / before)}%)"
+        )
     return new_cover, new_images

--- a/tests/unit/test_converter.py
+++ b/tests/unit/test_converter.py
@@ -389,26 +389,45 @@ class TestHalfTitlePage:
 
 
 class _OptsStub:
-    def __init__(self, embed): self.kfxgen_embed_original_images = embed
+    def __init__(self, embed):
+        self.kfxgen_embed_original_images = embed
 
 
 class _Log2:
-    def info(self, *a): pass
-    def warn(self, *a): pass
-    def debug(self, *a): pass
-    def error(self, *a): pass
+    def info(self, *a):
+        pass
+
+    def warn(self, *a):
+        pass
+
+    def debug(self, *a):
+        pass
+
+    def error(self, *a):
+        pass
 
 
 def _patch_pipeline(monkeypatch, captured):
-    monkeypatch.setattr(_conv, "extract_metadata",
-                        lambda *a, **k: {"title": "T", "author": "A",
-                                         "language": "en", "publisher": "P",
-                                         "issue_date": None})
-    monkeypatch.setattr(_conv, "extract_cover_image", lambda *a, **k: (b"COVER", "c.jpg"))
-    monkeypatch.setattr(_conv, "extract_images_from_oeb",
-                        lambda *a, **k: {"x.jpg": b"XX"})
-    monkeypatch.setattr(_conv, "extract_chapters_from_oeb",
-                        lambda *a, **k: [{"text": "hi"}])
+    monkeypatch.setattr(
+        _conv,
+        "extract_metadata",
+        lambda *a, **k: {
+            "title": "T",
+            "author": "A",
+            "language": "en",
+            "publisher": "P",
+            "issue_date": None,
+        },
+    )
+    monkeypatch.setattr(
+        _conv, "extract_cover_image", lambda *a, **k: (b"COVER", "c.jpg")
+    )
+    monkeypatch.setattr(
+        _conv, "extract_images_from_oeb", lambda *a, **k: {"x.jpg": b"XX"}
+    )
+    monkeypatch.setattr(
+        _conv, "extract_chapters_from_oeb", lambda *a, **k: [{"text": "hi"}]
+    )
 
     class _Gen:
         def generate_full_book(self, **kw):
@@ -417,6 +436,7 @@ def _patch_pipeline(monkeypatch, captured):
             # create the output file so the success branch passes
             with open(kw["output_path"], "wb") as f:
                 f.write(b"KFX")
+
     monkeypatch.setattr(_conv, "NativeKFXGenerator", lambda: _Gen())
 
 
@@ -425,9 +445,15 @@ def test_optimization_runs_by_default(monkeypatch, tmp_path):
     captured = {}
     _patch_pipeline(monkeypatch, captured)
     called = {}
-    monkeypatch.setattr(_conv, "optimize_images",
-                        lambda cover, images, log: (called.setdefault("yes", True), (b"C2", {"x.jpg": b"Y"}))[1],
-                        raising=False)
+    monkeypatch.setattr(
+        _conv,
+        "optimize_images",
+        lambda cover, images, log: (
+            called.setdefault("yes", True),
+            (b"C2", {"x.jpg": b"Y"}),
+        )[1],
+        raising=False,
+    )
     out = tmp_path / "o.kfx"
     _conv.convert_oeb_to_kfx(object(), str(out), _OptsStub(False), _Log2())
     assert called.get("yes") is True
@@ -439,9 +465,12 @@ def test_optimization_runs_by_default(monkeypatch, tmp_path):
 def test_optimization_skipped_when_embed_originals(monkeypatch, tmp_path):
     captured = {}
     _patch_pipeline(monkeypatch, captured)
-    monkeypatch.setattr(_conv, "optimize_images",
-                        lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not be called")),
-                        raising=False)
+    monkeypatch.setattr(
+        _conv,
+        "optimize_images",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("should not be called")),
+        raising=False,
+    )
     out = tmp_path / "o.kfx"
     _conv.convert_oeb_to_kfx(object(), str(out), _OptsStub(True), _Log2())
     assert captured["images"] == {"x.jpg": b"XX"}  # originals untouched

--- a/tests/unit/test_image_optimize.py
+++ b/tests/unit/test_image_optimize.py
@@ -6,22 +6,46 @@ from kfxgen import image_optimize as io
 
 
 def _png(w, h):
-    return (b"\x89PNG\r\n\x1a\n" + struct.pack(">I", 13) + b"IHDR"
-            + struct.pack(">II", w, h) + b"\x08\x02\x00\x00\x00")
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + struct.pack(">I", 13)
+        + b"IHDR"
+        + struct.pack(">II", w, h)
+        + b"\x08\x02\x00\x00\x00"
+    )
 
 
 def _jpeg(w, h):
     # SOI, APP0 stub, SOF0 (len=17, precision=8, height, width), EOI
-    app0 = b"\xff\xe0" + struct.pack(">H", 16) + b"JFIF\x00" + b"\x01\x01\x00" + b"\x00\x01\x00\x01\x00\x00"
-    sof0 = b"\xff\xc0" + struct.pack(">H", 17) + b"\x08" + struct.pack(">HH", h, w) + b"\x03\x01\x22\x00\x02\x11\x01\x03\x11\x01"
+    app0 = (
+        b"\xff\xe0"
+        + struct.pack(">H", 16)
+        + b"JFIF\x00"
+        + b"\x01\x01\x00"
+        + b"\x00\x01\x00\x01\x00\x00"
+    )
+    sof0 = (
+        b"\xff\xc0"
+        + struct.pack(">H", 17)
+        + b"\x08"
+        + struct.pack(">HH", h, w)
+        + b"\x03\x01\x22\x00\x02\x11\x01\x03\x11\x01"
+    )
     return b"\xff\xd8" + app0 + sof0 + b"\xff\xd9"
 
 
 class _Log:
-    def __init__(self): self.warns = []
-    def warn(self, m): self.warns.append(m)
-    def info(self, m): pass
-    def debug(self, m): pass
+    def __init__(self):
+        self.warns = []
+
+    def warn(self, m):
+        self.warns.append(m)
+
+    def info(self, m):
+        pass
+
+    def debug(self, m):
+        pass
 
 
 @pytest.mark.unit
@@ -136,8 +160,7 @@ def test_optimize_image_keeps_original_if_result_larger(monkeypatch):
 @pytest.mark.unit
 def test_optimize_images_maps_all_and_handles_none_cover(monkeypatch):
     # Force the per-image optimizer to a deterministic stub.
-    monkeypatch.setattr(io, "optimize_image",
-                        lambda data, **k: b"OPT" + data[:1])
+    monkeypatch.setattr(io, "optimize_image", lambda data, **k: b"OPT" + data[:1])
     cover, imgs = io.optimize_images(None, {"a.jpg": b"AAAA", "b.png": b"BBBB"}, _Log())
     assert cover is None
     assert imgs == {"a.jpg": b"OPTA", "b.png": b"OPTB"}


### PR DESCRIPTION
The #11 image-optimization files were hand-formatted and never run through `ruff format`, so the `ruff format --check .` CI job failed once PR #13 merged to main.

No logic change — pure formatting (exploded collections, slice whitespace, wrapped long calls). Verified locally with the CI-pinned ruff 0.15.1: `ruff format --check` and `ruff check` both clean, 350 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)