### PR TITLE
Inline emphasis: carry italic/bold through to KFX (Plan A of #9)

### DIFF
--- a/docs/superpowers/plans/2026-06-28-inline-emphasis.md
+++ b/docs/superpowers/plans/2026-06-28-inline-emphasis.md
@@ -1,0 +1,718 @@
+# Inline Emphasis Implementation Plan (Plan A of #9)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Carry inline `<em>/<i>/<strong>/<b>` emphasis from the source EPUB through to KFX as italic/bold/bold-italic character spans.
+
+**Architecture:** The converter produces, per paragraph, normalized text plus a list of `(start, length, flags)` emphasis spans (additive `chapter["blocks"]`; the flat `text` string is unchanged for existing heuristics). The generator emits each span as a `$142` character span referencing a deduped italic/bold `$157` style — reusing the existing `$142` link-span mechanism and the existing `_allocate_style` cache.
+
+**Tech Stack:** Python 3.13, pytest, lxml (Calibre OEB), the vendored `kfxlib_minimal` Ion library.
+
+**Scope note:** This is Plan A (inline emphasis only). The CSS subset (text-align, text-indent, margins) from the spec is Plan B, a separate plan after this lands — it needs CSS length→KFX unit conversion and the margin-symbol reconciliation, which are independent of emphasis.
+
+## Global Constraints
+
+- Python invoked as `python3.13` (or the repo venv); never bare `python`.
+- Lint gate is BOTH `ruff check .` and `ruff format --check .`, pinned to **ruff==0.15.1**. Run both before every commit.
+- Tests run with `pytest tests/unit -q`. Unit tests carry `@pytest.mark.unit`.
+- KFX symbols are authoritative (from jhowell's kfxlib): font-style = `$12`, italic value = `$382`, font-weight = `$13`, bold value = `$361`. The `$142` span uses `$143`=start, `$144`=length, `$157`=style; emphasis spans omit `$179` (that field is links only).
+- `flags` is a `frozenset` over the string constants `inline_style.FLAG_ITALIC` / `FLAG_BOLD`.
+- Default (non-emphasis) generator output must stay byte-identical — guard with the golden tests in Task 7.
+
+---
+
+### Task 1: `normalize_runs` — whitespace-collapsing span builder
+
+**Files:**
+- Create: `plugin/kfxgen/inline_style.py`
+- Test: `tests/unit/test_inline_style.py`
+
+**Interfaces:**
+- Produces: `FLAG_ITALIC: str`, `FLAG_BOLD: str`; `normalize_runs(segments: list[tuple[str, frozenset]]) -> tuple[str, list[tuple[int, int, frozenset]]]`. Input is `(text, flags)` segments in document order; output is the whitespace-normalized text (same rule as the existing `" ".join(text.split())`: every whitespace run collapses to one space, ends stripped) plus maximal `(start, length, flags)` spans where `flags` is non-empty, offsets into the returned text.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+import pytest
+from kfxgen import inline_style as ist
+from kfxgen.inline_style import FLAG_ITALIC as I, FLAG_BOLD as B
+
+
+@pytest.mark.unit
+def test_plain_text_no_spans():
+    text, spans = ist.normalize_runs([("hello world", frozenset())])
+    assert text == "hello world"
+    assert spans == []
+
+
+@pytest.mark.unit
+def test_single_italic_run():
+    text, spans = ist.normalize_runs(
+        [("a ", frozenset()), ("big", frozenset({I})), (" cat", frozenset())]
+    )
+    assert text == "a big cat"
+    assert spans == [(2, 3, frozenset({I}))]
+
+
+@pytest.mark.unit
+def test_whitespace_collapsed_and_stripped():
+    text, spans = ist.normalize_runs(
+        [("  a\n\n", frozenset()), ("  b  ", frozenset({B}))]
+    )
+    assert text == "a b"
+    assert spans == [(2, 1, frozenset({B}))]
+
+
+@pytest.mark.unit
+def test_bold_italic_combined_flags():
+    text, spans = ist.normalize_runs([("x", frozenset({I, B}))])
+    assert text == "x"
+    assert spans == [(0, 1, frozenset({I, B}))]
+
+
+@pytest.mark.unit
+def test_adjacent_same_flags_merge():
+    text, spans = ist.normalize_runs(
+        [("ab", frozenset({I})), ("cd", frozenset({I}))]
+    )
+    assert text == "abcd"
+    assert spans == [(0, 4, frozenset({I}))]
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `python3.13 -m pytest tests/unit/test_inline_style.py -q`
+Expected: FAIL (`ModuleNotFoundError` / `AttributeError: normalize_runs`).
+
+- [ ] **Step 3: Implement the module**
+
+```python
+"""Inline emphasis run/span computation for KFX styling (#9).
+
+Pure, Calibre-independent: turns a paragraph's ordered (text, flags) segments
+into whitespace-normalized text plus character spans, ready to become KFX $142
+spans. See docs/superpowers/specs/2026-06-28-inline-emphasis-css-typography-design.md.
+"""
+
+FLAG_ITALIC = "italic"
+FLAG_BOLD = "bold"
+
+
+def normalize_runs(segments):
+    """Collapse whitespace across (text, flags) segments and return
+    (normalized_text, spans). Mirrors the converter's existing
+    `" ".join(text.split())` rule: each run of ASCII whitespace becomes a
+    single space and leading/trailing space is stripped. `spans` are maximal
+    (start, length, flags) ranges with non-empty flags, offset into the text.
+    """
+    chars = []
+    flags_per_char = []
+    prev_space = True  # strip leading whitespace
+    for text, flags in segments:
+        for ch in text:
+            if ch.isspace():
+                if not prev_space:
+                    chars.append(" ")
+                    # a collapsed space carries its own segment's flags so
+                    # "italic italic" stays one span rather than fragmenting.
+                    flags_per_char.append(flags)
+                    prev_space = True
+            else:
+                chars.append(ch)
+                flags_per_char.append(flags)
+                prev_space = False
+    # strip trailing space
+    while chars and chars[-1] == " ":
+        chars.pop()
+        flags_per_char.pop()
+
+    text_out = "".join(chars)
+    spans = []
+    i = 0
+    n = len(flags_per_char)
+    while i < n:
+        f = flags_per_char[i]
+        if not f:
+            i += 1
+            continue
+        j = i + 1
+        while j < n and flags_per_char[j] == f:
+            j += 1
+        spans.append((i, j - i, f))
+        i = j
+    return text_out, spans
+```
+
+- [ ] **Step 4: Run tests, verify they pass**
+
+Run: `python3.13 -m pytest tests/unit/test_inline_style.py -q`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+ruff check plugin/kfxgen/inline_style.py tests/unit/test_inline_style.py
+ruff format plugin/kfxgen/inline_style.py tests/unit/test_inline_style.py
+git add plugin/kfxgen/inline_style.py tests/unit/test_inline_style.py
+git commit -m "feat(emphasis): normalize_runs span builder for inline styling (#9)"
+```
+
+---
+
+### Task 2: Extract emphasis blocks from XHTML
+
+**Files:**
+- Modify: `plugin/kfxgen/converter.py` (`_walk_paragraph_with_imgs`, add `extract_blocks_from_html`; refactor `extract_text_from_html` to delegate)
+- Test: `tests/unit/test_converter.py`
+
+**Interfaces:**
+- Consumes: `inline_style.normalize_runs`, `inline_style.FLAG_ITALIC/FLAG_BOLD`.
+- Produces: `extract_blocks_from_html(element) -> list[dict]` where each block is `{"text": str, "spans": list[(start, length, frozenset)]}`. `extract_text_from_html(element) -> str` is unchanged externally (now `"\n\n".join(b["text"] ...)`), so existing callers and tests keep working.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+import pytest
+from lxml import etree
+from kfxgen import converter
+from kfxgen.inline_style import FLAG_ITALIC as I, FLAG_BOLD as Bf
+
+XHTML = "{http://www.w3.org/1999/xhtml}"
+
+
+def _doc(body_inner):
+    return etree.fromstring(
+        f'<html xmlns="http://www.w3.org/1999/xhtml"><body>{body_inner}</body></html>'.encode()
+    )
+
+
+@pytest.mark.unit
+def test_blocks_capture_italic_span():
+    blocks = converter.extract_blocks_from_html(_doc("<p>a <em>big</em> cat</p>"))
+    assert len(blocks) == 1
+    assert blocks[0]["text"] == "a big cat"
+    assert blocks[0]["spans"] == [(2, 3, frozenset({I}))]
+
+
+@pytest.mark.unit
+def test_blocks_capture_bold_and_nested():
+    blocks = converter.extract_blocks_from_html(
+        _doc("<p><strong>x <em>y</em></strong></p>")
+    )
+    assert blocks[0]["text"] == "x y"
+    assert blocks[0]["spans"] == [
+        (0, 2, frozenset({Bf})),
+        (2, 1, frozenset({Bf, I})),
+    ]
+
+
+@pytest.mark.unit
+def test_extract_text_unchanged_delegates_to_blocks():
+    doc = _doc("<p>one</p><p>two <i>three</i></p>")
+    assert converter.extract_text_from_html(doc) == "one\n\ntwo three"
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `python3.13 -m pytest tests/unit/test_converter.py -q -k "blocks or delegates"`
+Expected: FAIL (`AttributeError: extract_blocks_from_html`).
+
+- [ ] **Step 3: Generalize the inline walk to emit (segment, flags)**
+
+In `converter.py`, add the emphasis tag map near the top (after imports):
+
+```python
+from .inline_style import FLAG_BOLD, FLAG_ITALIC, normalize_runs
+
+_ITALIC_TAGS = {"em", "i"}
+_BOLD_TAGS = {"strong", "b"}
+```
+
+Replace `_walk_paragraph_with_imgs` with a flag-accumulating walk that returns `(segment, flags)` pairs (IMG tokens get empty flags):
+
+```python
+def _walk_inline(elem, flags=frozenset()):
+    """Yield (segment, flags) pairs for inline content, accumulating italic/
+    bold from ancestor <em>/<i>/<strong>/<b>. <img> becomes an IMG token
+    segment with empty flags so the generator still splits on it."""
+    local = _local_tag(elem.tag)
+    cur = set(flags)
+    if local in _ITALIC_TAGS:
+        cur.add(FLAG_ITALIC)
+    if local in _BOLD_TAGS:
+        cur.add(FLAG_BOLD)
+    cur = frozenset(cur)
+    parts = []
+    if elem.text:
+        parts.append((elem.text, cur))
+    for child in elem:
+        clocal = _local_tag(child.tag)
+        if clocal == "img":
+            href = child.get("src", "") or ""
+            alt = child.get("alt", "") or ""
+            parts.append((_make_img_token(href, alt), frozenset()))
+        else:
+            parts.extend(_walk_inline(child, cur))
+        if child.tail:
+            parts.append((child.tail, flags))
+    return parts
+```
+
+- [ ] **Step 4: Add `extract_blocks_from_html` and delegate `extract_text_from_html`**
+
+Refactor the paragraph loop in `extract_text_from_html` into a block builder. Replace the body of `extract_text_from_html` so the block-finding logic lives in `extract_blocks_from_html`, and `extract_text_from_html` joins block texts:
+
+```python
+def extract_blocks_from_html(element):
+    """Like extract_text_from_html but returns structured blocks:
+    [{"text": str, "spans": [(start, length, frozenset)]}], preserving inline
+    emphasis as spans and inline <img> as IMG tokens in `text`."""
+    body = element.find(".//{http://www.w3.org/1999/xhtml}body")
+    if body is None:
+        body = element.find(".//body")
+    if body is None:
+        body = element
+
+    ns = "{http://www.w3.org/1999/xhtml}"
+    block_tags = set()
+    for tag in ("p", "div", "h1", "h2", "h3", "h4", "h5", "h6",
+                "blockquote", "li", "section", "article", "figure"):
+        block_tags.add(tag)
+        block_tags.add(ns + tag)
+
+    blocks = []
+    for elem in body.iter():
+        if elem.tag in block_tags:
+            if any(child.tag in block_tags for child in elem):
+                continue
+            text, spans = normalize_runs(_walk_inline(elem))
+            if text:
+                blocks.append({"text": text, "spans": spans})
+            continue
+        if _local_tag(elem.tag) == "img":
+            parent = elem.getparent()
+            if parent is not None and parent.tag in block_tags:
+                continue
+            href = elem.get("src", "") or ""
+            alt = elem.get("alt", "") or ""
+            blocks.append({"text": _make_img_token(href, alt), "spans": []})
+
+    if blocks:
+        return blocks
+
+    # Fallback: no block elements — flat extraction, no spans (unchanged rule).
+    text = body.xpath("string()")
+    lines = [line.strip() for line in text.split("\n")]
+    text = " ".join(line for line in lines if line)
+    return [{"text": text, "spans": []}] if text else []
+
+
+def extract_text_from_html(element):
+    """Plain-text extraction (IMG tokens preserved). Now derived from
+    extract_blocks_from_html so the two never diverge."""
+    return "\n\n".join(b["text"] for b in extract_blocks_from_html(element))
+```
+
+Delete the now-unused old `_walk_paragraph_with_imgs` if nothing else references it (grep first: `grep -rn _walk_paragraph_with_imgs plugin tests`).
+
+- [ ] **Step 5: Run tests, verify pass (including existing converter tests)**
+
+Run: `python3.13 -m pytest tests/unit/test_converter.py -q`
+Expected: PASS (new tests + all existing converter tests unchanged).
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+ruff check plugin/kfxgen/converter.py tests/unit/test_converter.py
+ruff format plugin/kfxgen/converter.py tests/unit/test_converter.py
+git add plugin/kfxgen/converter.py tests/unit/test_converter.py
+git commit -m "feat(emphasis): extract emphasis blocks from XHTML (#9)"
+```
+
+---
+
+### Task 3: Thread blocks onto chapters
+
+**Files:**
+- Modify: `plugin/kfxgen/converter.py` (`extract_chapters_from_oeb` spine extraction + assembly)
+- Test: `tests/unit/test_converter.py`
+
+**Interfaces:**
+- Produces: each chapter dict gains `chapter["blocks"]: list[{"text","spans"}]` aligned to the chapter's paragraphs. `blocks` is omitted/empty only when there is no structured text. The flat `chapter["text"]` is unchanged.
+
+- [ ] **Step 1: Write the failing test** (uses the existing OEB shim in the converter tests; mirror how other tests build `oeb_book`)
+
+```python
+@pytest.mark.unit
+def test_chapter_carries_emphasis_blocks(simple_oeb_with_italic):
+    # simple_oeb_with_italic: an OEB shim whose single spine item is
+    # <p>plain</p><p>see <em>this</em></p> (build with the same shim helper
+    # the other extract_chapters_from_oeb tests use).
+    import logging
+    chapters = converter.extract_chapters_from_oeb(
+        simple_oeb_with_italic, logging.getLogger("t")
+    )
+    blocks = chapters[0]["blocks"]
+    assert any(
+        b["spans"] and b["spans"][0][2] == frozenset({I}) for b in blocks
+    )
+```
+
+If no shim fixture exists, add one mirroring the existing `EpubAsOeb`/spine-item test scaffolding already in `tests/unit/test_converter.py` (reuse that file's helper that wraps XHTML strings as spine items).
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `python3.13 -m pytest tests/unit/test_converter.py -q -k emphasis_blocks`
+Expected: FAIL (`KeyError: 'blocks'`).
+
+- [ ] **Step 3: Carry blocks through spine extraction + assembly**
+
+In `extract_chapters_from_oeb`, where each spine item's text is computed (the `extract_text_from_html(item.data)` call), also compute blocks and store them parallel to text:
+
+```python
+            blocks = extract_blocks_from_html(item.data)
+            text = "\n\n".join(b["text"] for b in blocks)
+```
+
+Extend `spine_items_ordered` entries to carry blocks: `spine_items_ordered.append({"href": href, "text": text, "blocks": blocks})`.
+
+Where chapter text is assembled from a spine-index range (`parts = [...text...]; text = "\n\n".join(parts)`), assemble blocks the same way and attach:
+
+```python
+            block_parts = []
+            for k in range(start, end):
+                if spine_items_ordered[k]["text"]:
+                    block_parts.extend(spine_items_ordered[k]["blocks"])
+            chapter = {"title": entry["title"], "text": text}
+            if block_parts:
+                chapter["blocks"] = block_parts
+            chapters.append(chapter)
+```
+
+Apply the same `blocks` attachment in the other chapter-append sites (orphan recovery and the no-TOC fallback). For chapters whose text is synthesized (title-page replacement, rebuilt contents) leave `blocks` unset — those have no source emphasis and fall back to the flat path.
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `python3.13 -m pytest tests/unit/test_converter.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+ruff check plugin/kfxgen/converter.py tests/unit/test_converter.py
+ruff format plugin/kfxgen/converter.py tests/unit/test_converter.py
+git add plugin/kfxgen/converter.py tests/unit/test_converter.py
+git commit -m "feat(emphasis): carry emphasis blocks onto chapters (#9)"
+```
+
+---
+
+### Task 4: `build_fragment_157` — italic support
+
+**Files:**
+- Modify: `plugin/kfxgen/native_generator.py` (`build_fragment_157`)
+- Test: `tests/unit/test_native_generator.py`
+
+**Interfaces:**
+- Produces: `build_fragment_157(..., italic=False)` adds `value[IS("$12")] = IS("$382")` when `italic` is True; default-arg output is byte-identical to before.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+@pytest.mark.unit
+def test_italic_sets_font_style():
+    from kfxgen.kfxlib_minimal.ion import IS
+    gen = NativeKFXGenerator()
+    frag = gen.build_fragment_157(entity_name="s_it", italic=True)
+    assert frag.value[IS("$12")] == IS("$382")
+
+
+@pytest.mark.unit
+def test_no_italic_by_default():
+    from kfxgen.kfxlib_minimal.ion import IS
+    gen = NativeKFXGenerator()
+    frag = gen.build_fragment_157(entity_name="s_plain")
+    assert IS("$12") not in frag.value
+```
+
+- [ ] **Step 2: Run tests, verify they fail**
+
+Run: `python3.13 -m pytest tests/unit/test_native_generator.py -q -k italic`
+Expected: FAIL (`KeyError`/`$12` absent or unexpected presence).
+
+- [ ] **Step 3: Add the `italic` parameter**
+
+Add `italic=False` to the signature, and after the underline block insert:
+
+```python
+        # $12 = font-style: $382 = italic (authoritative, jhowell kfxlib)
+        if italic:
+            value[IS("$12")] = IS("$382")
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `python3.13 -m pytest tests/unit/test_native_generator.py -q -k "italic or style or align or margin or bold or underline"`
+Expected: PASS (new + existing style tests, confirming defaults unchanged).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+ruff check plugin/kfxgen/native_generator.py tests/unit/test_native_generator.py
+ruff format plugin/kfxgen/native_generator.py tests/unit/test_native_generator.py
+git add plugin/kfxgen/native_generator.py tests/unit/test_native_generator.py
+git commit -m "feat(emphasis): font-style italic in build_fragment_157 (#9)"
+```
+
+---
+
+### Task 5: `build_fragment_259` — emphasis spans
+
+**Files:**
+- Modify: `plugin/kfxgen/native_generator.py` (`build_fragment_259`)
+- Test: `tests/unit/test_native_generator.py`
+
+**Interfaces:**
+- Consumes: italic/bold `$157` style names (allocated by the caller in Task 6).
+- Produces: `build_fragment_259(..., emphasis_spans=None)` where `emphasis_spans[i]` is a list of `(start, length, style_name)` for child `i`. Each becomes a `$142` span `IonStruct($143=start, $144=length, $157=style_name)` (no `$179`). Existing `$142` link spans are preserved; emphasis spans append to the same `$142` list.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+@pytest.mark.unit
+def test_emphasis_spans_emit_142():
+    from kfxgen.kfxlib_minimal.ion import IS
+    gen = NativeKFXGenerator()
+    frag = gen.build_fragment_259(
+        ["s0"], content_name="content_1", entity_name="l0",
+        positions=[1001], outer_position=1000, outer_style="s0",
+        chunk_kinds=["text"],
+        emphasis_spans=[[(2, 3, "s0it")]],
+    )
+    child = frag.value[IS("$146")][0][IS("$146")][0]
+    spans = child[IS("$142")]
+    assert spans[0][IS("$143")] == 2
+    assert spans[0][IS("$144")] == 3
+    assert spans[0][IS("$157")] == IS("s0it")
+    assert IS("$179") not in spans[0]
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `python3.13 -m pytest tests/unit/test_native_generator.py -q -k emphasis_spans`
+Expected: FAIL (`TypeError: unexpected keyword 'emphasis_spans'`).
+
+- [ ] **Step 3: Emit emphasis spans**
+
+Add `emphasis_spans=None` to the signature. In the text-entry branch, after the existing link-span block (which may set `entry[IS("$142")]`), append emphasis spans to the same list:
+
+```python
+            if emphasis_spans and i < len(emphasis_spans) and emphasis_spans[i]:
+                existing = entry.get(IS("$142"), [])
+                for start, length, style_name in emphasis_spans[i]:
+                    self.symtab.create_local_symbol(style_name)
+                    existing.append(
+                        IonStruct(
+                            IS("$143"), start,
+                            IS("$144"), length,
+                            IS("$157"), IS(style_name),
+                        )
+                    )
+                entry[IS("$142")] = existing
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+Run: `python3.13 -m pytest tests/unit/test_native_generator.py -q -k "emphasis_spans or 259 or storyline"`
+Expected: PASS.
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+ruff check plugin/kfxgen/native_generator.py tests/unit/test_native_generator.py
+ruff format plugin/kfxgen/native_generator.py tests/unit/test_native_generator.py
+git add plugin/kfxgen/native_generator.py tests/unit/test_native_generator.py
+git commit -m "feat(emphasis): \$142 emphasis spans in build_fragment_259 (#9)"
+```
+
+---
+
+### Task 6: Wire blocks → chunk spans → emphasis styles in `_build_chapter_content`
+
+**Files:**
+- Modify: `plugin/kfxgen/native_generator.py` (`_build_chapter_content`)
+- Test: `tests/unit/test_native_generator.py`
+
+**Interfaces:**
+- Consumes: `chapter["blocks"]` (Task 3), `build_fragment_157(italic=, bold=)` (Task 4), `build_fragment_259(emphasis_spans=)` (Task 5), the existing `_allocate_style` cache.
+- Produces: text chunks carry `chunk["spans"]: list[(start, length, frozenset)]` rebased to the chunk; the `$259` build loop passes `emphasis_spans` with resolved style names; new emphasis styles are appended to `extra_style_names`.
+
+- [ ] **Step 1: Write the failing integration test**
+
+```python
+@pytest.mark.unit
+def test_emphasis_block_produces_italic_span_in_book(tmp_path):
+    from kfxgen.kfxlib_minimal.ion import IS
+    from kfxgen.inline_style import FLAG_ITALIC
+    gen = NativeKFXGenerator()
+    chapters = [{
+        "title": "Ch",
+        "text": "a big cat",
+        "blocks": [{"text": "a big cat", "spans": [(2, 3, frozenset({FLAG_ITALIC}))]}],
+    }]
+    out = tmp_path / "out.kfx"
+    gen.generate_full_book(title="T", author="A", chapters=chapters,
+                           output_path=str(out))
+    # An italic $157 ($12 -> $382) must exist among emitted fragments.
+    styles = [f for f in gen.fragments if str(f.ftype) == "$157"]
+    assert any(
+        IS("$12") in f.value and f.value[IS("$12")] == IS("$382")
+        for f in styles
+    )
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+Run: `python3.13 -m pytest tests/unit/test_native_generator.py -q -k emphasis_block_produces`
+Expected: FAIL (no italic `$157`).
+
+- [ ] **Step 3: Attach block spans to text chunks**
+
+In `_build_chapter_content`, the `else` branch that splits `chapter["text"]` into paragraphs is where blocks attach. When `chapter.get("blocks")` is present, iterate blocks instead of `text.split("\n\n")`, carrying spans. Replace the paragraph loop body so each paragraph processes its block:
+
+```python
+                blocks = chapter.get("blocks")
+                if blocks is not None:
+                    para_iter = blocks
+                else:
+                    para_iter = [{"text": p, "spans": []} for p in text.split("\n\n")]
+
+                for block in para_iter:
+                    para = block["text"].strip()
+                    if not para:
+                        continue
+                    para_spans = block.get("spans", [])
+                    for chunk in _emit_text_chunks(para):
+                        if chunk["type"] == "image":
+                            all_chunks.append(chunk)
+                        else:
+                            _append_text_with_spans(chunk["text"], para, para_spans)
+```
+
+Add a helper (near `_split_long_text`) that rebases paragraph spans onto each emitted text chunk. Because `_emit_text_chunks` strips segments and `_split_long_text` cuts at `CHUNK_SIZE`, map spans by locating the chunk text within the paragraph and intersecting ranges:
+
+```python
+        def _append_text_with_spans(chunk_text, para_text, para_spans):
+            """Split chunk_text by CHUNK_SIZE and attach the slice of
+            para_spans covering each piece, offsets rebased to the piece.
+            The chunk_text is a (stripped) substring of para_text; find its
+            offset once, then translate spans."""
+            base = para_text.find(chunk_text)
+            if base < 0:
+                base = 0  # defensive: emphasis simply won't apply to this chunk
+            pos = 0
+            while pos < len(chunk_text):
+                piece = chunk_text[pos : pos + self.CHUNK_SIZE]
+                p_start = base + pos
+                p_end = p_start + len(piece)
+                pspans = []
+                for s, length, flags in para_spans:
+                    a = max(s, p_start)
+                    b = min(s + length, p_end)
+                    if b > a:
+                        pspans.append((a - p_start, b - a, flags))
+                all_chunks.append({"type": "text", "text": piece, "spans": pspans})
+                pos += self.CHUNK_SIZE
+```
+
+(Replace the prior `all_chunks.extend(_split_long_text(chunk["text"]))` path for the blocks case; keep `_split_long_text` for any remaining non-block callers.)
+
+- [ ] **Step 4: Allocate emphasis styles and pass spans to `$259`**
+
+In the `$259` build loop, for each text chunk compute its emphasis spans with resolved style names. Add an emphasis-style allocator using the existing `_allocate_style`, and build `entry_emphasis_spans`:
+
+```python
+        from .inline_style import FLAG_BOLD, FLAG_ITALIC
+
+        def _emphasis_style(flags):
+            return _allocate_style(
+                "_em",
+                italic=FLAG_ITALIC in flags,
+                bold=FLAG_BOLD in flags,
+            )
+```
+
+Inside the loop over `chunk_idx`, in the text branch, after appending the entry's other per-chunk lists, build its emphasis spans (default empty):
+
+```python
+                chunk_spans = all_chunks[chunk_idx].get("spans", [])
+                entry_emphasis_spans.append(
+                    [(s, length, _emphasis_style(flags)) for (s, length, flags) in chunk_spans]
+                )
+```
+
+Initialize `entry_emphasis_spans = []` alongside the other `entry_*` lists, and append `None` for image entries (mirroring `entry_link_targets`). Styles created by `_emphasis_style` must be registered: after the chapter loop, add any `_em` styles from `style_cache` to `extra_style_names` (they are needed in `$419`/`$270`). Simplest: in `_allocate_style`, when `kind == "_em"` and the name is newly created, append it to `extra_style_names`. Pass the new list to `build_fragment_259(..., emphasis_spans=entry_emphasis_spans)`.
+
+- [ ] **Step 5: Run tests, verify pass**
+
+Run: `python3.13 -m pytest tests/unit/test_native_generator.py -q`
+Expected: PASS (new integration test + all existing generator tests).
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+ruff check plugin/kfxgen/native_generator.py tests/unit/test_native_generator.py
+ruff format plugin/kfxgen/native_generator.py tests/unit/test_native_generator.py
+git add plugin/kfxgen/native_generator.py tests/unit/test_native_generator.py
+git commit -m "feat(emphasis): wire emphasis spans+styles through chapter content (#9)"
+```
+
+---
+
+### Task 7: Golden coverage + byte-stable-default guard
+
+**Files:**
+- Modify: `tests/unit/test_native_generator.py` (or the golden test module)
+- Possibly add: a small emphasis fixture under `tests/fixtures/`
+
+**Interfaces:**
+- Consumes: the full pipeline from Tasks 1–6.
+
+- [ ] **Step 1: Add a default-stability test (guards margin/output regressions)**
+
+```python
+@pytest.mark.unit
+def test_plain_chapter_emits_no_emphasis_fragments(tmp_path):
+    from kfxgen.kfxlib_minimal.ion import IS
+    gen = NativeKFXGenerator()
+    chapters = [{"title": "Ch", "text": "plain text only"}]  # no blocks
+    gen.generate_full_book(title="T", author="A", chapters=chapters,
+                           output_path=str(tmp_path / "o.kfx"))
+    styles = [f for f in gen.fragments if str(f.ftype) == "$157"]
+    assert all(IS("$12") not in f.value for f in styles)  # no italic anywhere
+```
+
+- [ ] **Step 2: Run the full unit suite**
+
+Run: `python3.13 -m pytest tests/unit -q`
+Expected: PASS (all). If any existing golden fixture compares bytes, confirm it is unchanged; the no-blocks path must not alter default output.
+
+- [ ] **Step 3: Lint everything + commit**
+
+```bash
+ruff check . && ruff format --check .
+git add -A
+git commit -m "test(emphasis): default-stability guard for inline emphasis (#9)"
+```
+
+- [ ] **Step 4: Manual device-verification note (release gate, not automated)**
+
+Convert an EPUB containing `<em>`/`<strong>` runs with the built plugin and confirm italic/bold render on a physical Kindle before tagging a release. Record the result on issue #9. (Device tests are the repo's release gate and are not part of CI.)
+
+---
+
+## Self-review
+
+- **Spec coverage:** Inline emphasis (italic/bold/bold-italic) — Tasks 1–6. Spans as `$142` — Task 5. Nested/combined flags — Tasks 1, 2 tests. Style dedup — reuses existing `_allocate_style` (Task 6). Byte-stable defaults — Task 7. Device gate — Task 7 Step 4. The CSS subset (align/indent/margins) is explicitly deferred to Plan B (stated up front) — not a gap, a scoping decision.
+- **Placeholders:** none — every code/test step has concrete code.
+- **Type consistency:** `flags` is `frozenset` throughout (Tasks 1–6); span tuples are `(start, length, flags)` in extraction and `(start, length, style_name)` at the `$142` emission boundary (translated in Task 6 Step 4); `normalize_runs`, `extract_blocks_from_html`, `build_fragment_157(italic=)`, `build_fragment_259(emphasis_spans=)` signatures match across tasks.

--- a/docs/superpowers/specs/2026-06-28-inline-emphasis-css-typography-design.md
+++ b/docs/superpowers/specs/2026-06-28-inline-emphasis-css-typography-design.md
@@ -1,0 +1,161 @@
+# Design: Inline emphasis + CSS typography subset (#9)
+
+Date: 2026-06-28
+Issue: #9 (Carry inline emphasis and more CSS typography through to KFX styles)
+Status: Approved (brainstorming) — pending spec review
+
+## Problem
+
+The native generator emits a fixed set of paragraph-level `$157` styles. Inline
+formatting (`<em>/<i>/<strong>/<b>`) is dropped entirely, and most per-element
+CSS typography from the source EPUB is not carried through. Books lose italic
+and bold *within* paragraphs, and lose per-element indent/alignment/spacing.
+
+## Scope
+
+In scope:
+1. **Inline emphasis** — italic, bold, bold-italic — as KFX character spans.
+2. **CSS subset** — `text-align`, `text-indent`, `margin-top`/`margin-bottom`,
+   resolved per element.
+
+Out of scope (non-goals): color, letter-spacing, floats/positioning, and any
+CSS KFX cannot represent. `oblique` is mapped to italic.
+
+## Feasibility — confirmed symbols
+
+The issue claimed the `$157` vocabulary "includes the needed symbols". The
+bundled `yj_symbol_catalog.py` is **anonymized** (symbols are `"$10"`, `"$13"`,
+`"$14?"`) and carries no semantic meaning; the meanings used today were
+reverse-engineered and hardcoded in `native_generator.py`. font-style/italic was
+used nowhere and was unverified.
+
+Resolved authoritatively from jhowell's upstream `kfxlib`
+(`KFX Input.zip` → `kfxlib/yj_to_epub_properties.py`):
+
+| CSS property | symbol | values |
+|---|---|---|
+| font-style | `$12` | `$382`=italic, `$381`=oblique |
+| font-weight | `$13` | `$361`=bold (+ `$357`=300, `$359`=500, `$363`=900) |
+| text-align | `$34` | `$320`=center, `$321`=justify, `$59`=left, `$61`=right |
+| text-indent | `$36` | (length value) |
+| margin | `$46` shorthand, `$47`=top, `$48`=left, `$49`=bottom, `$50`=right | |
+| font-family | `$11` | (bonus — the symbol #15/#16 need) |
+
+Note: the authoritative margin mapping (`$47`=margin-top, `$48`=margin-left,
+`$49`=margin-bottom) **disagrees with the current `build_fragment_157` code
+comments** (which label `$48` "margin-bottom" and `$47` "padding-top"). Current
+output is device-tested and renders correctly, so this must be reconciled
+carefully — see Risks.
+
+## Architecture
+
+### Data model (converter → generator)
+
+Add `chapter["blocks"]`: ordered list of paragraph blocks, each:
+
+```python
+{
+  "kind": "text",
+  "runs": [(text, flags), ...],          # flags: subset of {"italic","bold"}
+  "spans": [(start, length, flags), ...], # offsets into normalized block text
+  "block_style": {                        # None/empty when unavailable
+     "align": "...", "indent": "...",
+     "margin_top": "...", "margin_bottom": "...",
+  },
+}
+```
+
+`spans` cover only non-default runs, as character offsets into the block's
+**normalized** text. The existing flat `text` string is still produced; the
+title-strip, cover, image-only, and `toc_links` heuristics keep using it
+unchanged. `blocks` is **additive**: when absent (tests passing raw text, or the
+no-Stylizer fallback), the generator uses today's flat path. This bounds blast
+radius.
+
+### Extraction (`converter.py`)
+
+- Generalize `_walk_paragraph_with_imgs` to walk inline content accumulating
+  italic/bold from ancestor `<em>/<i>/<strong>/<b>`, returning `(segment, flags)`
+  pairs. IMG tokens stay as point markers.
+- Normalize whitespace across the styled segments collectively, emitting
+  normalized text + offset spans (only where flags != default).
+- Block style via **Calibre Stylizer**
+  (`calibre.ebooks.oeb.stylizer.Stylizer`) when available: compute effective
+  `text-align`/`text-indent`/margins per element. Wrap in try/except → fall back
+  to no block style (today's behavior) outside Calibre. Mirrors the
+  image-optimizer's calibre-optional pattern.
+
+### Generation (`native_generator.py`)
+
+- `build_fragment_157`: add `italic` (`$12`→`$382`); accept per-element
+  `align`/`indent`/`margin_top`/`margin_bottom` instead of fixed values. Add a
+  **style cache** keyed by the style tuple to dedup near-identical `$157`
+  fragments (prevents proliferation across thousands of paragraphs).
+- Emphasis styles: a small fixed set — italic, bold, bold-italic — referenced by
+  spans.
+- `build_fragment_259` already emits `$142` spans for links; extend it to emit
+  emphasis spans (`$142` with `$143` start / `$144` length / `$157` style, no
+  `$179`). A chunk may carry both link and emphasis spans → multiple `$142`
+  entries.
+- `_build_chapter_content`: when `blocks` is present, build text chunks from
+  blocks, slicing each block's spans onto the resulting chunk char ranges (after
+  `.strip()` and length-split) and rebasing offsets. Title/heading/cover/toc/
+  image-only logic is preserved.
+
+## Data flow
+
+1. `extract_chapters_from_oeb` builds chapters; for each block it computes runs +
+   spans (inline tags) and block_style (Stylizer).
+2. Chapter carries both `text` (flat, for heuristics) and `blocks` (structured).
+3. `_build_chapter_content` consumes `blocks` → typed chunks, each with its span
+   list (offsets rebased to the chunk) and a resolved/`cached` `$157` style name.
+4. `build_fragment_259` emits each chunk's entry with `$142` emphasis spans;
+   `build_fragment_157` emits the deduped styles.
+
+## Edge cases
+
+- Nested emphasis (`<strong>` inside `<em>`) → flags combine → bold-italic.
+- Adjacent/overlapping spans of equal flags merged.
+- Emphasis crossing an inline image → split at the image boundary (images are
+  separate chunks).
+- Whitespace at run boundaries handled by collective normalization.
+- Degenerate/empty runs dropped.
+- Style proliferation bounded by the style cache.
+
+## Error handling
+
+- Stylizer import/compute failure → block_style omitted, never raises (fallback
+  to current behavior). Emphasis (structural tags) is independent of Stylizer
+  and still works.
+- Unknown/oblique font-style → italic. Unmappable CSS values → omitted.
+
+## Testing
+
+- **Unit (no Calibre):** `<em>/<i>/<strong>/<b>` and nesting → assert `$142`
+  emphasis spans + italic/bold `$157`, via the existing OEB test shim.
+- **CSS subset:** unit-test the style-mapping function with a mocked
+  computed-style dict; test the graceful no-op fallback when Stylizer is absent.
+- **Golden:** add an emphasis-bearing EPUB→KFX fixture. Assert default
+  (non-emphasis) styles stay **byte-stable** to catch margin-reconciliation
+  regressions.
+- **Device (release gate):** italic/bold actually render on a Kindle.
+
+## Risks
+
+1. **Margin reconciliation (highest).** Adopt the authoritative mapping, but the
+   rule is: default styles stay byte-identical (locked by golden test);
+   per-element margins are only *added* when Stylizer reports non-default values.
+   No change to the existing default style bytes.
+2. **Chunk/span slicing.** Rebasing block spans onto post-strip, length-split
+   chunk text is fiddly; covered by targeted unit tests with multi-chunk
+   paragraphs.
+3. **Stylizer availability/signature** across Calibre versions — isolated behind
+   the try/except fallback; CSS subset simply degrades to off when it can't run.
+
+## Boundary with related issues
+
+- #15/#16 (font embedding): this builds the inline-run/span model fonts need;
+  `font-family` is `$11` (recorded above) and slots into the same span/style
+  machinery later.
+- #18 (catalog drift): this work consumed jhowell's upstream catalog to resolve
+  unverified symbols — a concrete instance of the sync process #18 proposes.

--- a/plugin/kfxgen/converter.py
+++ b/plugin/kfxgen/converter.py
@@ -16,7 +16,11 @@ from ._img_tokens import (
     IMG_TOKEN_SPACE as _IMG_TOKEN_SPACE,
 )
 from .image_optimize import optimize_images
+from .inline_style import FLAG_BOLD, FLAG_ITALIC, normalize_runs
 from .native_generator import NativeKFXGenerator
+
+_ITALIC_TAGS = {"em", "i"}
+_BOLD_TAGS = {"strong", "b"}
 
 _security_log = logging.getLogger(__name__ + ".security")
 
@@ -52,46 +56,37 @@ def _make_img_token(href, alt):
     )
 
 
-def _walk_paragraph_with_imgs(elem):
-    """Build the inline content of a paragraph, preserving <img> tags as
-    IMG tokens at their source positions.
-
-    Tokens are decoded by the chunker in NativeKFXGenerator and emitted
-    as nested $259 image entries pointing at the matching $164 resource.
-    """
+def _walk_inline(elem, flags=frozenset()):
+    """Yield (segment, flags) pairs for inline content, accumulating italic/
+    bold from ancestor <em>/<i>/<strong>/<b>. <img> becomes an IMG token
+    segment with empty flags so the generator still splits on it."""
+    local = _local_tag(elem.tag)
+    cur = set(flags)
+    if local in _ITALIC_TAGS:
+        cur.add(FLAG_ITALIC)
+    if local in _BOLD_TAGS:
+        cur.add(FLAG_BOLD)
+    cur = frozenset(cur)
     parts = []
     if elem.text:
-        parts.append(elem.text)
+        parts.append((elem.text, cur))
     for child in elem:
-        local = _local_tag(child.tag)
-        if local == "img":
+        clocal = _local_tag(child.tag)
+        if clocal == "img":
             href = child.get("src", "") or ""
             alt = child.get("alt", "") or ""
-            parts.append(_make_img_token(href, alt))
+            parts.append((_make_img_token(href, alt), frozenset()))
         else:
-            parts.append(_walk_paragraph_with_imgs(child))
+            parts.extend(_walk_inline(child, cur))
         if child.tail:
-            parts.append(child.tail)
-    return "".join(parts)
+            parts.append((child.tail, flags))
+    return parts
 
 
-def extract_text_from_html(element):
-    """
-    Extract text from an lxml HTML element's body, preserving inline <img>
-    tags as placeholder tokens.
-
-    Each <img src="..." alt="..."/> becomes a token string of the form
-    \\x00IMG\\x01<src>\\x01<alt>\\x00 inserted in document-order position. The
-    downstream chunking step (in NativeKFXGenerator._build_chapter_content)
-    parses these tokens into nested $259 image entries.
-
-    Args:
-        element: lxml element (root of XHTML document)
-
-    Returns:
-        str: Extracted text with paragraph breaks preserved as \\n\\n and
-             inline image tokens preserved at their source positions.
-    """
+def extract_blocks_from_html(element):
+    """Like extract_text_from_html but returns structured blocks:
+    [{"text": str, "spans": [(start, length, frozenset)]}], preserving inline
+    emphasis as spans and inline <img> as IMG tokens in `text`."""
     body = element.find(".//{http://www.w3.org/1999/xhtml}body")
     if body is None:
         body = element.find(".//body")
@@ -118,18 +113,14 @@ def extract_text_from_html(element):
         block_tags.add(tag)
         block_tags.add(ns + tag)
 
-    paragraphs = []
+    blocks = []
     for elem in body.iter():
         if elem.tag in block_tags:
-            has_block_child = any(child.tag in block_tags for child in elem)
-            if has_block_child:
+            if any(child.tag in block_tags for child in elem):
                 continue
-            content = _walk_paragraph_with_imgs(elem)
-            # Tokens use only non-whitespace control chars, so ' '.join(split())
-            # collapses normal whitespace runs without fragmenting tokens.
-            normalized = " ".join(content.split()).strip()
-            if normalized:
-                paragraphs.append(normalized)
+            text, spans = normalize_runs(_walk_inline(elem))
+            if text:
+                blocks.append({"text": text, "spans": spans})
             continue
 
         # Bare <img> directly under body (rare, but exists in some EPUBs)
@@ -139,16 +130,22 @@ def extract_text_from_html(element):
                 continue  # already handled by the block walker above
             href = elem.get("src", "") or ""
             alt = elem.get("alt", "") or ""
-            paragraphs.append(_make_img_token(href, alt))
+            blocks.append({"text": _make_img_token(href, alt), "spans": []})
 
-    if paragraphs:
-        return "\n\n".join(paragraphs)
+    if blocks:
+        return blocks
 
-    # Fallback: no block elements — flat extraction, no token support
+    # Fallback: no block elements — flat extraction, no spans (unchanged rule).
     text = body.xpath("string()")
     lines = [line.strip() for line in text.split("\n")]
     text = " ".join(line for line in lines if line)
-    return text
+    return [{"text": text, "spans": []}] if text else []
+
+
+def extract_text_from_html(element):
+    """Plain-text extraction (IMG tokens preserved). Now derived from
+    extract_blocks_from_html so the two never diverge."""
+    return "\n\n".join(b["text"] for b in extract_blocks_from_html(element))
 
 
 def extract_metadata(oeb_book, log):

--- a/plugin/kfxgen/converter.py
+++ b/plugin/kfxgen/converter.py
@@ -358,7 +358,8 @@ def extract_chapters_from_oeb(oeb_book, log, metadata=None):
         try:
             if not hasattr(item, "data") or item.data is None:
                 continue
-            text = extract_text_from_html(item.data)
+            blocks = extract_blocks_from_html(item.data)
+            text = "\n\n".join(b["text"] for b in blocks)
         except Exception as e:
             href_for_log = getattr(item, "href", "") or "<unknown>"
             log.warn(f"  Spine item {i + 1} parse failed ({href_for_log}): {e}")
@@ -373,7 +374,7 @@ def extract_chapters_from_oeb(oeb_book, log, metadata=None):
 
         spine_map[norm_href] = text
         spine_map[href] = text
-        spine_items_ordered.append({"href": href, "text": text})
+        spine_items_ordered.append({"href": href, "text": text, "blocks": blocks})
         log.info(f"  Spine item {i + 1}: {len(text)} chars ({norm_href})")
 
     if not spine_items_ordered:
@@ -480,7 +481,14 @@ def extract_chapters_from_oeb(oeb_book, log, metadata=None):
             ]
             text = "\n\n".join(parts)
             if text.strip():
-                chapters.append({"title": entry["title"], "text": text})
+                chapter = {"title": entry["title"], "text": text}
+                block_parts = []
+                for k in range(start, end):
+                    if spine_items_ordered[k]["text"]:
+                        block_parts.extend(spine_items_ordered[k]["blocks"])
+                if block_parts:
+                    chapter["blocks"] = block_parts
+                chapters.append(chapter)
                 covered_spine_indices.update(range(start, end))
 
         # Recover spine items the TOC never references. This fires when
@@ -526,7 +534,10 @@ def extract_chapters_from_oeb(oeb_book, log, metadata=None):
                         norm = _normalize_href(item["href"])
                         stem = norm.rsplit(".", 1)[0] if "." in norm else norm
                         title = stem or f"Section {k + 1}"
-                    chapters.append({"title": title, "text": item["text"]})
+                    chapter = {"title": title, "text": item["text"]}
+                    if item.get("blocks"):
+                        chapter["blocks"] = item["blocks"]
+                    chapters.append(chapter)
 
         if chapters:
             log.info(f"Mapped {len(chapters)} TOC entries to spine content")
@@ -540,7 +551,10 @@ def extract_chapters_from_oeb(oeb_book, log, metadata=None):
     # Fallback: use each spine item as a chapter
     chapters = []
     for i, item in enumerate(spine_items_ordered):
-        chapters.append({"title": f"Section {i + 1}", "text": item["text"]})
+        chapter = {"title": f"Section {i + 1}", "text": item["text"]}
+        if item.get("blocks"):
+            chapter["blocks"] = item["blocks"]
+        chapters.append(chapter)
 
     log.info(f"Using {len(chapters)} spine items as chapters (no TOC mapping)")
     _replace_title_page(chapters, metadata, log)

--- a/plugin/kfxgen/converter.py
+++ b/plugin/kfxgen/converter.py
@@ -613,6 +613,7 @@ def _replace_title_page(chapters, metadata, log):
         ch_title = ch["title"].lower().strip()
         if ch_title in TITLE_PAGE_TITLES:
             ch["text"] = f"{title}\n\nby\n\n{author}"
+            ch.pop("blocks", None)
             # The replaced body already contains the book title — don't
             # also render the chapter's TOC name ("Title Page") as a
             # heading on top of it (#33).
@@ -624,6 +625,7 @@ def _replace_title_page(chapters, metadata, log):
             # printed content — replace with the title and suppress the
             # label as a heading so it can't leak onto the page. (#107)
             ch["text"] = title
+            ch.pop("blocks", None)
             ch["_omit_title_heading"] = True
             log.info(f"  Replaced half-title page with: {title}")
         elif ch_title in ("copyright", "copyright page"):
@@ -632,6 +634,7 @@ def _replace_title_page(chapters, metadata, log):
         elif ch_title in ("contents", "table of contents"):
             # Rebuild contents page from actual chapter titles
             _rebuild_contents_page(ch, chapters, log)
+            ch.pop("blocks", None)
             ch["font_size"] = SMALL_FONT_SIZE
 
         if ch_title in SMALL_TEXT_CHAPTERS:
@@ -668,6 +671,7 @@ def _rebuild_contents_page(contents_ch, all_chapters, log):
     for link in toc_links:
         lines.append(link["text"])
     contents_ch["text"] = "\n\n".join(lines)
+    contents_ch.pop("blocks", None)
 
     # Structured link data for the native generator
     contents_ch["toc_links"] = toc_links

--- a/plugin/kfxgen/inline_style.py
+++ b/plugin/kfxgen/inline_style.py
@@ -1,0 +1,54 @@
+"""Inline emphasis run/span computation for KFX styling (#9).
+
+Pure, Calibre-independent: turns a paragraph's ordered (text, flags) segments
+into whitespace-normalized text plus character spans, ready to become KFX $142
+spans. See docs/superpowers/specs/2026-06-28-inline-emphasis-css-typography-design.md.
+"""
+
+FLAG_ITALIC = "italic"
+FLAG_BOLD = "bold"
+
+
+def normalize_runs(segments):
+    """Collapse whitespace across (text, flags) segments and return
+    (normalized_text, spans). Mirrors the converter's existing
+    `" ".join(text.split())` rule: each run of ASCII whitespace becomes a
+    single space and leading/trailing space is stripped. `spans` are maximal
+    (start, length, flags) ranges with non-empty flags, offset into the text.
+    """
+    chars = []
+    flags_per_char = []
+    prev_space = True  # strip leading whitespace
+    for text, flags in segments:
+        for ch in text:
+            if ch.isspace():
+                if not prev_space:
+                    chars.append(" ")
+                    # a collapsed space carries its own segment's flags so
+                    # "italic italic" stays one span rather than fragmenting.
+                    flags_per_char.append(flags)
+                    prev_space = True
+            else:
+                chars.append(ch)
+                flags_per_char.append(flags)
+                prev_space = False
+    # strip trailing space
+    while chars and chars[-1] == " ":
+        chars.pop()
+        flags_per_char.pop()
+
+    text_out = "".join(chars)
+    spans = []
+    i = 0
+    n = len(flags_per_char)
+    while i < n:
+        f = flags_per_char[i]
+        if not f:
+            i += 1
+            continue
+        j = i + 1
+        while j < n and flags_per_char[j] == f:
+            j += 1
+        spans.append((i, j - i, f))
+        i = j
+    return text_out, spans

--- a/plugin/kfxgen/native_generator.py
+++ b/plugin/kfxgen/native_generator.py
@@ -1267,29 +1267,14 @@ class NativeKFXGenerator:
 
             children.append(entry)
 
-        # Phase 3 nested shape: a single outer entry wraps all children.
-        effective_outer_style = (
-            outer_style
-            if outer_style
-            else (story_names[0] if story_names else entity_name)
-        )
-        self.symtab.create_local_symbol(effective_outer_style)
-        effective_outer_pos = outer_position if outer_position is not None else 0
-        outer_entry = IonStruct(
-            IS("$155"),
-            effective_outer_pos,
-            IS("$157"),
-            IS(effective_outer_style),
-            IS("$159"),
-            IS("$269"),
-            IS("$146"),
-            children,
-        )
+        # FLAT shape (pre-Phase-3) — used for the TOC-regression test.
+        # Whether to revert nesting permanently or fix the nested shape
+        # depends on the device test outcome.
         value = IonStruct(
             IS("$176"),
             IS(entity_name),
             IS("$146"),
-            [outer_entry],
+            children,
         )
 
         return YJFragment(fid=IS(entity_name), ftype=IS("$259"), value=value)

--- a/plugin/kfxgen/native_generator.py
+++ b/plugin/kfxgen/native_generator.py
@@ -928,6 +928,7 @@ class NativeKFXGenerator:
         bold=False,
         margin_top=None,
         is_heading=False,
+        italic=False,
     ):
         """
         Builds Fragment $157 (Style Definition).
@@ -943,6 +944,7 @@ class NativeKFXGenerator:
             line_height: Line height in lh units (default 1.0, matching reference KFX)
             underline: If True, add text-decoration: underline ($23: $328)
             bold: If True, set font-weight: bold ($13: $361)
+            italic: If True, add font-style: italic ($12: $382)
             is_heading: If True, omit padding-top (headings use margin-top for spacing)
 
         Returns:
@@ -995,6 +997,10 @@ class NativeKFXGenerator:
         # $23: $328 = text-decoration: underline
         if underline:
             value[IS("$23")] = IS("$328")
+
+        # $12 = font-style: $382 = italic (authoritative, jhowell kfxlib)
+        if italic:
+            value[IS("$12")] = IS("$382")
 
         # $46 = margin-top (for visual separation before chapter headings)
         if margin_top is not None:

--- a/plugin/kfxgen/native_generator.py
+++ b/plugin/kfxgen/native_generator.py
@@ -2214,6 +2214,28 @@ class NativeKFXGenerator:
                 pos += self.CHUNK_SIZE
             return chunks
 
+        def _append_text_with_spans(chunk_text, para_text, para_spans):
+            """Split chunk_text by CHUNK_SIZE and attach the slice of
+            para_spans covering each piece, offsets rebased to the piece.
+            The chunk_text is a (stripped) substring of para_text; find its
+            offset once, then translate spans."""
+            base = para_text.find(chunk_text)
+            if base < 0:
+                base = 0  # defensive: emphasis simply won't apply to this chunk
+            pos = 0
+            while pos < len(chunk_text):
+                piece = chunk_text[pos : pos + self.CHUNK_SIZE]
+                p_start = base + pos
+                p_end = p_start + len(piece)
+                pspans = []
+                for s, length, flags in para_spans:
+                    a = max(s, p_start)
+                    b = min(s + length, p_end)
+                    if b > a:
+                        pspans.append((a - p_start, b - a, flags))
+                all_chunks.append({"type": "text", "text": piece, "spans": pspans})
+                pos += self.CHUNK_SIZE
+
         for ch_idx, chapter in enumerate(chapters):
             start_idx = len(all_chunks)
             title = chapter["title"]
@@ -2260,16 +2282,24 @@ class NativeKFXGenerator:
                 if stripped[: len(title)].lower() == title.lower():
                     text = stripped[len(title) :].lstrip()
                 if text:
-                    paras = text.split("\n\n")
-                    for para in paras:
-                        para = para.strip()
+                    blocks = chapter.get("blocks")
+                    if blocks is not None:
+                        para_iter = blocks
+                    else:
+                        para_iter = [
+                            {"text": p, "spans": []} for p in text.split("\n\n")
+                        ]
+
+                    for block in para_iter:
+                        para = block["text"].strip()
                         if not para:
                             continue
+                        para_spans = block.get("spans", [])
                         for chunk in _emit_text_chunks(para):
                             if chunk["type"] == "image":
                                 all_chunks.append(chunk)
                             else:
-                                all_chunks.extend(_split_long_text(chunk["text"]))
+                                _append_text_with_spans(chunk["text"], para, para_spans)
 
             # Guarantee every chapter contributes at least one chunk so it
             # owns a navigable content position and the per-chapter arrays
@@ -2364,6 +2394,8 @@ class NativeKFXGenerator:
             name = f"s{idx}{kind}"
             style_cache[key] = name
             self.fragments.append(self.build_fragment_157(entity_name=name, **attrs))
+            if kind == "_em" and name not in extra_style_names:
+                extra_style_names.append(name)
             return name
 
         for i, chapter in enumerate(chapters):
@@ -2443,6 +2475,15 @@ class NativeKFXGenerator:
             kind = _classify(w, h)
             return image_style_names.get(kind) or image_style_names.get("inline")
 
+        from .inline_style import FLAG_BOLD, FLAG_ITALIC
+
+        def _emphasis_style(flags):
+            return _allocate_style(
+                "_em",
+                italic=FLAG_ITALIC in flags,
+                bold=FLAG_BOLD in flags,
+            )
+
         # With per-chapter $145 fragments (#2), each chapter's $259
         # entries address into their OWN content fragment, so $403
         # indices reset to 0 at the start of every chapter.
@@ -2461,6 +2502,7 @@ class NativeKFXGenerator:
             entry_link_text_lengths = []
             entry_kinds = []
             entry_image_specs = []
+            entry_emphasis_spans = []
             for chunk_idx in range(start, end):
                 chunk = all_chunks[chunk_idx]
                 if chunk.get("type") == "image":
@@ -2474,6 +2516,7 @@ class NativeKFXGenerator:
                     entry_image_specs.append(
                         {"resource": chunk["resource"], "alt": chunk.get("alt", "")}
                     )
+                    entry_emphasis_spans.append(None)
                     continue
                 entry_kinds.append("text")
                 entry_image_specs.append(None)
@@ -2495,6 +2538,13 @@ class NativeKFXGenerator:
                     entry_link_targets.append(None)
                     entry_link_styles.append(None)
                     entry_link_text_lengths.append(None)
+                chunk_spans = chunk.get("spans", [])
+                entry_emphasis_spans.append(
+                    [
+                        (s, length, _emphasis_style(flags))
+                        for (s, length, flags) in chunk_spans
+                    ]
+                )
 
             frag_259 = self.build_fragment_259(
                 entry_styles,
@@ -2509,6 +2559,7 @@ class NativeKFXGenerator:
                 outer_style=story_names[ch_idx],
                 chunk_kinds=entry_kinds,
                 image_specs=entry_image_specs,
+                emphasis_spans=entry_emphasis_spans,
             )
             storyline_names.append(sl_name)
             self.fragments.append(frag_259)

--- a/plugin/kfxgen/native_generator.py
+++ b/plugin/kfxgen/native_generator.py
@@ -2284,7 +2284,31 @@ class NativeKFXGenerator:
                 if text:
                     blocks = chapter.get("blocks")
                     if blocks is not None:
-                        para_iter = blocks
+                        iter_blocks = list(blocks)
+                        if iter_blocks:
+                            first = iter_blocks[0]
+                            first_stripped = first["text"].lstrip()
+                            if first_stripped[: len(title)].lower() == title.lower():
+                                remainder = first_stripped[len(title) :].lstrip()
+                                removed = len(first["text"]) - len(remainder)
+                                rebased_spans = []
+                                for s, length, flags in first.get("spans", []):
+                                    new_s = s - removed
+                                    new_end = s + length - removed
+                                    start = max(new_s, 0)
+                                    end = min(new_end, len(remainder))
+                                    if end > start:
+                                        rebased_spans.append(
+                                            (start, end - start, flags)
+                                        )
+                                if remainder:
+                                    iter_blocks[0] = {
+                                        "text": remainder,
+                                        "spans": rebased_spans,
+                                    }
+                                else:
+                                    iter_blocks = iter_blocks[1:]
+                        para_iter = iter_blocks
                     else:
                         para_iter = [
                             {"text": p, "spans": []} for p in text.split("\n\n")

--- a/plugin/kfxgen/native_generator.py
+++ b/plugin/kfxgen/native_generator.py
@@ -1109,6 +1109,7 @@ class NativeKFXGenerator:
         outer_style=None,
         chunk_kinds=None,
         image_specs=None,
+        emphasis_spans=None,
     ):
         """
         Builds Fragment $259 (Storyline / Flow Map)
@@ -1248,16 +1249,47 @@ class NativeKFXGenerator:
                 )
                 entry[IS("$142")] = [span]
 
+            if emphasis_spans and i < len(emphasis_spans) and emphasis_spans[i]:
+                existing = entry.get(IS("$142"), [])
+                for start, length, style_name in emphasis_spans[i]:
+                    self.symtab.create_local_symbol(style_name)
+                    existing.append(
+                        IonStruct(
+                            IS("$143"),
+                            start,
+                            IS("$144"),
+                            length,
+                            IS("$157"),
+                            IS(style_name),
+                        )
+                    )
+                entry[IS("$142")] = existing
+
             children.append(entry)
 
-        # FLAT shape (pre-Phase-3) — used for the TOC-regression test.
-        # Whether to revert nesting permanently or fix the nested shape
-        # depends on the device test outcome.
+        # Phase 3 nested shape: a single outer entry wraps all children.
+        effective_outer_style = (
+            outer_style
+            if outer_style
+            else (story_names[0] if story_names else entity_name)
+        )
+        self.symtab.create_local_symbol(effective_outer_style)
+        effective_outer_pos = outer_position if outer_position is not None else 0
+        outer_entry = IonStruct(
+            IS("$155"),
+            effective_outer_pos,
+            IS("$157"),
+            IS(effective_outer_style),
+            IS("$159"),
+            IS("$269"),
+            IS("$146"),
+            children,
+        )
         value = IonStruct(
             IS("$176"),
             IS(entity_name),
             IS("$146"),
-            children,
+            [outer_entry],
         )
 
         return YJFragment(fid=IS(entity_name), ftype=IS("$259"), value=value)

--- a/tests/unit/test_converter.py
+++ b/tests/unit/test_converter.py
@@ -513,3 +513,20 @@ def test_blocks_capture_bold_and_nested():
 def test_extract_text_unchanged_delegates_to_blocks():
     doc = _doc("<p>one</p><p>two <i>three</i></p>")
     assert _conv.extract_text_from_html(doc) == "one\n\ntwo three"
+
+
+# ── Task 3: Thread emphasis blocks onto chapters ──────────────────────────────
+
+
+@pytest.fixture
+def simple_oeb_with_italic():
+    item = _SpineItem("chap.xhtml", "see <em>this</em>")
+    toc = [_TOCNode("Chapter 1", "chap.xhtml")]
+    return _OEBBook(spine=[item], toc=toc)
+
+
+@pytest.mark.unit
+def test_chapter_carries_emphasis_blocks(simple_oeb_with_italic):
+    chapters = extract_chapters_from_oeb(simple_oeb_with_italic, _silent_log())
+    blocks = chapters[0]["blocks"]
+    assert any(b["spans"] and b["spans"][0][2] == frozenset({I}) for b in blocks)

--- a/tests/unit/test_converter.py
+++ b/tests/unit/test_converter.py
@@ -388,6 +388,29 @@ class TestHalfTitlePage:
         assert TITLE_PAGE_TITLES <= CONTENTS_SKIP_TITLES
 
 
+@pytest.mark.unit
+def test_replace_title_page_clears_stale_blocks():
+    """Chapters whose text is synthesised must not retain stale blocks (#9)."""
+    dummy_blocks = [{"spans": [("old text", "old text", frozenset())]}]
+    chapters = [
+        # Title page — blocks must be cleared after text replacement.
+        {"title": "Title Page", "text": "old", "blocks": list(dummy_blocks)},
+        # Half-title page — same invariant.
+        {"title": "Half Title", "text": "old", "blocks": list(dummy_blocks)},
+        # Contents page — _rebuild_contents_page replaces text, blocks must go.
+        {"title": "Contents", "text": "old", "blocks": list(dummy_blocks)},
+        # Normal chapter — blocks must be left untouched.
+        {"title": "Chapter 1", "text": "body", "blocks": list(dummy_blocks)},
+    ]
+    meta = {"title": "MyBook", "author": "A. Author"}
+    _replace_title_page(chapters, meta, _silent_log())
+
+    assert "blocks" not in chapters[0], "title page blocks not cleared"
+    assert "blocks" not in chapters[1], "half-title page blocks not cleared"
+    assert "blocks" not in chapters[2], "contents page blocks not cleared"
+    assert "blocks" in chapters[3], "normal chapter blocks wrongly cleared"
+
+
 class _OptsStub:
     def __init__(self, embed):
         self.kfxgen_embed_original_images = embed

--- a/tests/unit/test_converter.py
+++ b/tests/unit/test_converter.py
@@ -475,3 +475,41 @@ def test_optimization_skipped_when_embed_originals(monkeypatch, tmp_path):
     _conv.convert_oeb_to_kfx(object(), str(out), _OptsStub(True), _Log2())
     assert captured["images"] == {"x.jpg": b"XX"}  # originals untouched
     assert captured["cover"] == b"COVER"
+
+
+# ── Task 2: extract_blocks_from_html ─────────────────────────────────────────
+
+from kfxgen.inline_style import FLAG_BOLD as Bf  # noqa: E402
+from kfxgen.inline_style import FLAG_ITALIC as I  # noqa: E402, N816
+
+
+def _doc(body_inner):
+    return etree.fromstring(
+        f'<html xmlns="http://www.w3.org/1999/xhtml"><body>{body_inner}</body></html>'.encode()
+    )
+
+
+@pytest.mark.unit
+def test_blocks_capture_italic_span():
+    blocks = _conv.extract_blocks_from_html(_doc("<p>a <em>big</em> cat</p>"))
+    assert len(blocks) == 1
+    assert blocks[0]["text"] == "a big cat"
+    assert blocks[0]["spans"] == [(2, 3, frozenset({I}))]
+
+
+@pytest.mark.unit
+def test_blocks_capture_bold_and_nested():
+    blocks = _conv.extract_blocks_from_html(
+        _doc("<p><strong>x <em>y</em></strong></p>")
+    )
+    assert blocks[0]["text"] == "x y"
+    assert blocks[0]["spans"] == [
+        (0, 2, frozenset({Bf})),
+        (2, 1, frozenset({Bf, I})),
+    ]
+
+
+@pytest.mark.unit
+def test_extract_text_unchanged_delegates_to_blocks():
+    doc = _doc("<p>one</p><p>two <i>three</i></p>")
+    assert _conv.extract_text_from_html(doc) == "one\n\ntwo three"

--- a/tests/unit/test_inline_style.py
+++ b/tests/unit/test_inline_style.py
@@ -1,0 +1,42 @@
+import pytest
+from kfxgen import inline_style as ist
+from kfxgen.inline_style import FLAG_ITALIC as I, FLAG_BOLD as B
+
+
+@pytest.mark.unit
+def test_plain_text_no_spans():
+    text, spans = ist.normalize_runs([("hello world", frozenset())])
+    assert text == "hello world"
+    assert spans == []
+
+
+@pytest.mark.unit
+def test_single_italic_run():
+    text, spans = ist.normalize_runs(
+        [("a ", frozenset()), ("big", frozenset({I})), (" cat", frozenset())]
+    )
+    assert text == "a big cat"
+    assert spans == [(2, 3, frozenset({I}))]
+
+
+@pytest.mark.unit
+def test_whitespace_collapsed_and_stripped():
+    text, spans = ist.normalize_runs(
+        [("  a\n\n", frozenset()), ("  b  ", frozenset({B}))]
+    )
+    assert text == "a b"
+    assert spans == [(2, 1, frozenset({B}))]
+
+
+@pytest.mark.unit
+def test_bold_italic_combined_flags():
+    text, spans = ist.normalize_runs([("x", frozenset({I, B}))])
+    assert text == "x"
+    assert spans == [(0, 1, frozenset({I, B}))]
+
+
+@pytest.mark.unit
+def test_adjacent_same_flags_merge():
+    text, spans = ist.normalize_runs([("ab", frozenset({I})), ("cd", frozenset({I}))])
+    assert text == "abcd"
+    assert spans == [(0, 4, frozenset({I}))]

--- a/tests/unit/test_native_generator.py
+++ b/tests/unit/test_native_generator.py
@@ -196,6 +196,20 @@ class TestBuildFragment157:
         frag = gen.build_fragment_157(entity_name="s_ul", underline=True)
         assert frag.value[IS("$23")] == IS("$328")
 
+    def test_italic_sets_font_style(self):
+        from kfxgen.kfxlib_minimal.ion import IS
+
+        gen = NativeKFXGenerator()
+        frag = gen.build_fragment_157(entity_name="s_it", italic=True)
+        assert frag.value[IS("$12")] == IS("$382")
+
+    def test_no_italic_by_default(self):
+        from kfxgen.kfxlib_minimal.ion import IS
+
+        gen = NativeKFXGenerator()
+        frag = gen.build_fragment_157(entity_name="s_plain")
+        assert IS("$12") not in frag.value
+
 
 class TestStyleSharing:
     """Issue #5: $157 styles must be shared globally, not cloned per chapter.

--- a/tests/unit/test_native_generator.py
+++ b/tests/unit/test_native_generator.py
@@ -146,6 +146,62 @@ class TestPerParagraphChunking:
             f"Content positions ({max_content_pos}) overlap with section positions ({min_section_pos})"
         )
 
+    @pytest.mark.unit
+    def test_blocks_title_prefix_stripped_no_duplicate(self):
+        # When blocks[0].text equals the chapter title, the title must appear
+        # exactly once across all chunks (heading chunk only, not also as body).
+        gen = NativeKFXGenerator()
+        chapters = [
+            {
+                "title": "Chapter 1",
+                "text": "Chapter 1\n\nbody",
+                "blocks": [
+                    {"text": "Chapter 1", "spans": []},
+                    {"text": "body", "spans": []},
+                ],
+            }
+        ]
+        result = gen._build_chapter_content(chapters)
+        texts = [c["text"] for c in result["all_chunks"] if c["type"] == "text"]
+        assert texts.count("Chapter 1") == 1, f"Title duplicated in chunks: {texts}"
+        assert texts == ["Chapter 1", "body"]
+
+    @pytest.mark.unit
+    def test_blocks_title_prefix_span_rebased(self):
+        # When blocks[0] has "Title rest" with an italic span on "rest",
+        # stripping the title prefix must rebase the span offset correctly.
+        from kfxgen.inline_style import FLAG_ITALIC
+
+        gen = NativeKFXGenerator()
+        # First block: "Chapter 1 italic" where "italic" (chars 10-16) is italic.
+        # Title "Chapter 1" (len 9) + space = 10 chars removed after lstrip.
+        # Span (10, 6, {FLAG_ITALIC}) -> rebased to (0, 6, {FLAG_ITALIC}).
+        chapters = [
+            {
+                "title": "Chapter 1",
+                "text": "Chapter 1 italic\n\nbody",
+                "blocks": [
+                    {"text": "Chapter 1 italic", "spans": [(10, 6, {FLAG_ITALIC})]},
+                    {"text": "body", "spans": []},
+                ],
+            }
+        ]
+        result = gen._build_chapter_content(chapters)
+        texts = [c["text"] for c in result["all_chunks"] if c["type"] == "text"]
+        assert texts[0] == "Chapter 1", f"Expected heading first, got: {texts}"
+        assert texts[1] == "italic", f"Expected rebased remainder second, got: {texts}"
+        italic_chunk = next(
+            c
+            for c in result["all_chunks"]
+            if c["type"] == "text" and c["text"] == "italic"
+        )
+        spans = italic_chunk.get("spans", [])
+        assert len(spans) == 1, f"Expected one span on 'italic' chunk, got: {spans}"
+        s, length, flags = spans[0]
+        assert s == 0, f"Rebased span start should be 0, got {s}"
+        assert length == 6, f"Rebased span length should be 6, got {length}"
+        assert FLAG_ITALIC in flags, f"Expected FLAG_ITALIC in flags, got {flags}"
+
 
 class TestBuildFragment157:
     """Test style fragment building."""

--- a/tests/unit/test_native_generator.py
+++ b/tests/unit/test_native_generator.py
@@ -948,3 +948,16 @@ def test_emphasis_block_produces_italic_span_in_book(tmp_path):
     assert any(
         IS("$12") in f.value and f.value[IS("$12")] == IS("$382") for f in styles
     )
+
+
+@pytest.mark.unit
+def test_plain_chapter_emits_no_emphasis_fragments(tmp_path):
+    from kfxgen.kfxlib_minimal.ion import IS
+
+    gen = NativeKFXGenerator()
+    chapters = [{"title": "Ch", "text": "plain text only"}]  # no blocks
+    gen.generate_full_book(
+        title="T", author="A", chapters=chapters, output_path=str(tmp_path / "o.kfx")
+    )
+    styles = [f for f in gen.fragments if str(f.ftype) == "$157"]
+    assert all(IS("$12") not in f.value for f in styles)  # no italic anywhere

--- a/tests/unit/test_native_generator.py
+++ b/tests/unit/test_native_generator.py
@@ -922,3 +922,29 @@ def test_emphasis_spans_emit_142():
     assert spans[0][IS("$144")] == 3
     assert spans[0][IS("$157")] == IS("s0it")
     assert IS("$179") not in spans[0]
+
+
+@pytest.mark.unit
+def test_emphasis_block_produces_italic_span_in_book(tmp_path):
+    from kfxgen.kfxlib_minimal.ion import IS
+    from kfxgen.inline_style import FLAG_ITALIC
+
+    gen = NativeKFXGenerator()
+    chapters = [
+        {
+            "title": "Ch",
+            "text": "a big cat",
+            "blocks": [
+                {"text": "a big cat", "spans": [(2, 3, frozenset({FLAG_ITALIC}))]}
+            ],
+        }
+    ]
+    out = tmp_path / "out.kfx"
+    gen.generate_full_book(
+        title="T", author="A", chapters=chapters, output_path=str(out)
+    )
+    # An italic $157 ($12 -> $382) must exist among emitted fragments.
+    styles = [f for f in gen.fragments if str(f.ftype) == "$157"]
+    assert any(
+        IS("$12") in f.value and f.value[IS("$12")] == IS("$382") for f in styles
+    )

--- a/tests/unit/test_native_generator.py
+++ b/tests/unit/test_native_generator.py
@@ -916,7 +916,7 @@ def test_emphasis_spans_emit_142():
         chunk_kinds=["text"],
         emphasis_spans=[[(2, 3, "s0it")]],
     )
-    child = frag.value[IS("$146")][0][IS("$146")][0]
+    child = frag.value[IS("$146")][0]
     spans = child[IS("$142")]
     assert spans[0][IS("$143")] == 2
     assert spans[0][IS("$144")] == 3

--- a/tests/unit/test_native_generator.py
+++ b/tests/unit/test_native_generator.py
@@ -10,6 +10,8 @@ import sys
 import tempfile
 from unittest.mock import MagicMock
 
+import pytest
+
 
 # Add plugin directory to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "plugin"))
@@ -897,3 +899,26 @@ class TestHalfTitlePageEndToEnd:
         assert "The Real Title" in chunk_texts
         # Real chapters are unaffected.
         assert "Chapter 1" in chunk_texts
+
+
+@pytest.mark.unit
+def test_emphasis_spans_emit_142():
+    from kfxgen.kfxlib_minimal.ion import IS
+
+    gen = NativeKFXGenerator()
+    frag = gen.build_fragment_259(
+        ["s0"],
+        content_name="content_1",
+        entity_name="l0",
+        positions=[1001],
+        outer_position=1000,
+        outer_style="s0",
+        chunk_kinds=["text"],
+        emphasis_spans=[[(2, 3, "s0it")]],
+    )
+    child = frag.value[IS("$146")][0][IS("$146")][0]
+    spans = child[IS("$142")]
+    assert spans[0][IS("$143")] == 2
+    assert spans[0][IS("$144")] == 3
+    assert spans[0][IS("$157")] == IS("s0it")
+    assert IS("$179") not in spans[0]


### PR DESCRIPTION
Implements **Plan A of #9** — carry inline `<em>/<i>/<strong>/<b>` emphasis from the source EPUB through to KFX as italic/bold/bold-italic `$142` character spans. The CSS subset (text-align/indent/margins) is deliberately deferred to a separate Plan B.

## Approach

Additive and low-risk, reusing existing KFX structures:
- **`inline_style.normalize_runs`** (new pure module): turns a paragraph's `(text, flags)` segments into whitespace-normalized text + `(start, length, flags)` emphasis spans.
- **Converter**: `extract_blocks_from_html` captures emphasis into `chapter["blocks"]` (the flat `chapter["text"]` is unchanged for existing heuristics). `extract_text_from_html` now delegates to it.
- **Generator**: `build_fragment_157` gains `italic` (`$12`→`$382`, authoritative from jhowell's kfxlib); `build_fragment_259` emits `$142` emphasis spans (no `$179`); `_build_chapter_content` slices block spans onto chunks and resolves them to deduped italic/bold `$157` styles via the existing `_allocate_style` cache.

## Correctness

- **Byte-stable defaults**: books with no emphasis produce unchanged output; `$259` stays flat. Guarded by tests.
- Three defects caught in review and fixed before merge: stale blocks on title-replaced chapters; an out-of-scope `$259` flat→nested change (reverted); and a title-duplication regression (final review) that would have affected all books — fixed with parity tests.
- 367 unit tests pass; `ruff check` + `ruff format --check` clean.

## Not covered

- CSS subset (Plan B).
- **Device verification**: italic/bold rendering on a physical Kindle is the repo's release gate and has not been run — should be confirmed before tagging a release.

Spec: `docs/superpowers/specs/2026-06-28-inline-emphasis-css-typography-design.md`
Plan: `docs/superpowers/plans/2026-06-28-inline-emphasis.md`

Partially addresses #9 — emphasis portion only. The CSS subset (Plan B) remains open under #9, so this PR intentionally does NOT auto-close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
