### PR TITLE
CSS typography: per-element text-align + text-indent (Plan B of #9)

### DIFF
--- a/docs/superpowers/plans/2026-06-28-css-typography.md
+++ b/docs/superpowers/plans/2026-06-28-css-typography.md
@@ -1,0 +1,740 @@
+# CSS Typography Subset Implementation Plan (Plan B of #9)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Carry per-element `text-align` and `text-indent` from the source EPUB through to KFX styles, resolved via Calibre's Stylizer with a graceful no-Calibre fallback.
+
+**Architecture:** Pure helpers in `inline_style.py` parse/map CSS values to KFX symbols; `converter.py` resolves per-element computed CSS via a Stylizer-backed `style_resolver` and attaches `block_style` to each block; `native_generator.py` overrides the fixed `$34`/`$36` in `build_fragment_157` and threads `block_style` through the existing `_allocate_style` cache. Builds directly on Plan A's `blocks` data model.
+
+**Tech Stack:** Python 3.13, pytest, lxml/Calibre OEB + Stylizer, the vendored `kfxlib_minimal`.
+
+## Global Constraints
+
+- Python invoked as `python3.13` / the repo venv at `/private/tmp/claude-501/-Users-justin-GitHub-kfxgen-public/0a357a5c-3454-41ea-a7c4-2fcc79a97b37/scratchpad/venv/bin`; never bare `python`.
+- Lint gate is BOTH `ruff check .` and `ruff format --check .`, pinned **ruff==0.15.1**. Run both before every commit.
+- KFX `$306` length-unit symbols: em=`$308`, rem=`$505`, %=`$314`, pt=`$318`, px=`$319`, mm=`$316`, lh=`$310`.
+- text-align symbols (`$34`): center=`$320`, justify=`$321`, left=`$59`, right=`$61`.
+- A source CSS length maps to KFX by unit-mapping, not numeric conversion. Unsupported units (`vw`,`vh`,`ch`,`ex`), `auto`, and zero magnitude → no override.
+- **Behaviors:** honor every source text-align incl. `left` (fall back to justify only when source is unset); when a paragraph has non-zero text-indent, suppress its `$47` padding-top.
+- **Byte-stable defaults:** blocks with no `block_style` (no Stylizer / unset CSS) must produce output identical to Plan A. Verified in Task 8.
+- `block_style` carries the raw align keyword (str) and a pre-parsed `(mag, unit_sym)` indent; `ALIGN_MAP` is applied only in `build_fragment_157`.
+
+---
+
+### Task 1: `parse_css_length`
+
+**Files:**
+- Modify: `plugin/kfxgen/inline_style.py`
+- Test: `tests/unit/test_inline_style.py`
+
+**Interfaces:**
+- Produces: `parse_css_length(value: str) -> tuple[str, str] | None` — returns `(magnitude_str, unit_symbol)` or `None`. Magnitude preserved as a trimmed string (e.g. `"1.5"`); unit mapped to its `$306` symbol.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+@pytest.mark.unit
+def test_parse_css_length_units():
+    assert ist.parse_css_length("1.5em") == ("1.5", "$308")
+    assert ist.parse_css_length("2rem") == ("2", "$505")
+    assert ist.parse_css_length("5%") == ("5", "$314")
+    assert ist.parse_css_length("12pt") == ("12", "$318")
+    assert ist.parse_css_length("3px") == ("3", "$319")
+    assert ist.parse_css_length("4mm") == ("4", "$316")
+
+
+@pytest.mark.unit
+def test_parse_css_length_rejects():
+    assert ist.parse_css_length("") is None
+    assert ist.parse_css_length("auto") is None
+    assert ist.parse_css_length("0") is None
+    assert ist.parse_css_length("0em") is None
+    assert ist.parse_css_length("2vw") is None
+    assert ist.parse_css_length("3ch") is None
+    assert ist.parse_css_length("inherit") is None
+```
+
+(Add `from kfxgen import inline_style as ist` if not already imported at the top of the test file — it is, from Plan A.)
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `<venv>/bin/pytest tests/unit/test_inline_style.py -q -k parse_css_length`
+Expected: FAIL (`AttributeError: parse_css_length`).
+
+- [ ] **Step 3: Implement**
+
+Append to `plugin/kfxgen/inline_style.py`:
+
+```python
+import re
+
+#: CSS length unit -> KFX $306 unit symbol.
+_CSS_UNIT_TO_KFX = {
+    "em": "$308",
+    "rem": "$505",
+    "%": "$314",
+    "pt": "$318",
+    "px": "$319",
+    "mm": "$316",
+}
+
+_LENGTH_RE = re.compile(r"^\s*([+-]?[0-9]*\.?[0-9]+)\s*(em|rem|%|pt|px|mm)\s*$", re.I)
+
+
+def parse_css_length(value):
+    """Parse a CSS length string into (magnitude_str, kfx_unit_symbol).
+
+    Returns None for empty/auto/inherit, unsupported units, or a zero
+    magnitude (no override needed). Magnitude is returned as a trimmed
+    string so the caller can hand it to IonDecimal unchanged.
+    """
+    if not value:
+        return None
+    m = _LENGTH_RE.match(value)
+    if not m:
+        return None
+    mag, unit = m.group(1), m.group(2).lower()
+    try:
+        if float(mag) == 0.0:
+            return None
+    except ValueError:
+        return None
+    # Normalize "2.0" -> "2", "1.50" -> "1.5" without forcing a float repr.
+    mag = mag.strip()
+    if "." in mag:
+        mag = mag.rstrip("0").rstrip(".")
+    return (mag, _CSS_UNIT_TO_KFX[unit])
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `<venv>/bin/pytest tests/unit/test_inline_style.py -q -k parse_css_length`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+<venv>/bin/ruff check plugin/kfxgen/inline_style.py tests/unit/test_inline_style.py
+<venv>/bin/ruff format plugin/kfxgen/inline_style.py tests/unit/test_inline_style.py
+git add plugin/kfxgen/inline_style.py tests/unit/test_inline_style.py
+git commit -m "feat(css): parse_css_length CSS-length-to-KFX-unit mapper (#9)"
+```
+
+---
+
+### Task 2: `ALIGN_MAP` + `compute_block_style`
+
+**Files:**
+- Modify: `plugin/kfxgen/inline_style.py`
+- Test: `tests/unit/test_inline_style.py`
+
+**Interfaces:**
+- Consumes: `parse_css_length` (Task 1).
+- Produces: `ALIGN_MAP: dict[str,str]`; `compute_block_style(css: dict) -> dict` returning `{"align": str|None, "indent": tuple|None}`. `align` is the raw CSS keyword (one of left/right/center/justify) or `None`; `indent` is a `(mag, unit_sym)` tuple or `None`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+@pytest.mark.unit
+def test_align_map_values():
+    assert ist.ALIGN_MAP == {
+        "left": "$59", "right": "$61", "center": "$320", "justify": "$321",
+    }
+
+
+@pytest.mark.unit
+def test_compute_block_style_align():
+    assert ist.compute_block_style({"text-align": "center"})["align"] == "center"
+    assert ist.compute_block_style({"text-align": "left"})["align"] == "left"
+    assert ist.compute_block_style({"text-align": "JUSTIFY"})["align"] == "justify"
+    assert ist.compute_block_style({"text-align": "start"})["align"] is None
+    assert ist.compute_block_style({})["align"] is None
+
+
+@pytest.mark.unit
+def test_compute_block_style_indent():
+    assert ist.compute_block_style({"text-indent": "1.5em"})["indent"] == ("1.5", "$308")
+    assert ist.compute_block_style({"text-indent": "0"})["indent"] is None
+    assert ist.compute_block_style({})["indent"] is None
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `<venv>/bin/pytest tests/unit/test_inline_style.py -q -k "align_map or compute_block_style"`
+Expected: FAIL (`AttributeError: ALIGN_MAP` / `compute_block_style`).
+
+- [ ] **Step 3: Implement**
+
+Append to `plugin/kfxgen/inline_style.py`:
+
+```python
+#: CSS text-align keyword -> KFX $34 value symbol.
+ALIGN_MAP = {"left": "$59", "right": "$61", "center": "$320", "justify": "$321"}
+
+
+def compute_block_style(css):
+    """Map a computed-CSS dict to kfxgen's block_style shape.
+
+    `css` is a mapping that supports .get(prop) returning CSS strings (e.g. a
+    Calibre Stylizer Style, or a plain dict in tests). Returns
+    {"align": <keyword or None>, "indent": <(mag, unit_sym) or None>}.
+    The align keyword is mapped to a symbol later, in build_fragment_157.
+    """
+    align = None
+    raw_align = (css.get("text-align") or "").strip().lower()
+    if raw_align in ALIGN_MAP:
+        align = raw_align
+    indent = parse_css_length(css.get("text-indent") or "")
+    return {"align": align, "indent": indent}
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `<venv>/bin/pytest tests/unit/test_inline_style.py -q -k "align_map or compute_block_style"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+<venv>/bin/ruff check plugin/kfxgen/inline_style.py tests/unit/test_inline_style.py
+<venv>/bin/ruff format plugin/kfxgen/inline_style.py tests/unit/test_inline_style.py
+git add plugin/kfxgen/inline_style.py tests/unit/test_inline_style.py
+git commit -m "feat(css): ALIGN_MAP + compute_block_style (#9)"
+```
+
+---
+
+### Task 3: `extract_blocks_from_html` accepts a `style_resolver`
+
+**Files:**
+- Modify: `plugin/kfxgen/converter.py` (`extract_blocks_from_html`, currently line ~86)
+- Test: `tests/unit/test_converter.py`
+
+**Interfaces:**
+- Consumes: `inline_style.compute_block_style` (Task 2).
+- Produces: `extract_blocks_from_html(element, style_resolver=None) -> list[dict]`; each block dict gains `"block_style": {"align","indent"} | None`. When `style_resolver` is `None`, `block_style` is `None` (Plan A behavior). `style_resolver` is a callable `elem -> css_dict | None`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+@pytest.mark.unit
+def test_blocks_block_style_from_resolver():
+    doc = _doc("<p>centered</p><p>plain</p>")  # _doc helper exists from Plan A
+
+    def resolver(elem):
+        # first <p> centered + indented, second has nothing
+        txt = "".join(elem.itertext())
+        if "centered" in txt:
+            return {"text-align": "center", "text-indent": "2em"}
+        return {}
+
+    blocks = converter.extract_blocks_from_html(doc, style_resolver=resolver)
+    assert blocks[0]["block_style"] == {"align": "center", "indent": ("2", "$308")}
+    assert blocks[1]["block_style"] == {"align": None, "indent": None}
+
+
+@pytest.mark.unit
+def test_blocks_block_style_none_without_resolver():
+    doc = _doc("<p>x</p>")
+    blocks = converter.extract_blocks_from_html(doc)
+    assert blocks[0]["block_style"] is None
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `<venv>/bin/pytest tests/unit/test_converter.py -q -k block_style`
+Expected: FAIL (`TypeError: unexpected keyword 'style_resolver'` or `KeyError: 'block_style'`).
+
+- [ ] **Step 3: Implement**
+
+Add the import near the other inline_style import (converter.py line ~19):
+
+```python
+from .inline_style import FLAG_BOLD, FLAG_ITALIC, compute_block_style, normalize_runs
+```
+
+Change the signature and the block-building loop in `extract_blocks_from_html`. The current loop appends `{"text": text, "spans": spans}` for each block element; add `block_style`:
+
+```python
+def extract_blocks_from_html(element, style_resolver=None):
+    ...
+    for elem in body.iter():
+        if elem.tag in block_tags:
+            if any(child.tag in block_tags for child in elem):
+                continue
+            text, spans = normalize_runs(_walk_inline(elem))
+            if text:
+                bstyle = None
+                if style_resolver is not None:
+                    css = style_resolver(elem)
+                    if css is not None:
+                        bstyle = compute_block_style(css)
+                blocks.append({"text": text, "spans": spans, "block_style": bstyle})
+            continue
+        if _local_tag(elem.tag) == "img":
+            ...
+            blocks.append({"text": _make_img_token(href, alt), "spans": [], "block_style": None})
+```
+
+Also add `"block_style": None` to the no-block fallback return at the end (`[{"text": text, "spans": [], "block_style": None}]`).
+
+- [ ] **Step 4: Run, verify pass (incl. existing converter tests)**
+
+Run: `<venv>/bin/pytest tests/unit/test_converter.py -q`
+Expected: PASS (new + all existing). `extract_text_from_html` is unaffected (it joins `b["text"]`).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+<venv>/bin/ruff check plugin/kfxgen/converter.py tests/unit/test_converter.py
+<venv>/bin/ruff format plugin/kfxgen/converter.py tests/unit/test_converter.py
+git add plugin/kfxgen/converter.py tests/unit/test_converter.py
+git commit -m "feat(css): block_style via style_resolver in extract_blocks_from_html (#9)"
+```
+
+---
+
+### Task 4: Stylizer-backed resolver in `extract_chapters_from_oeb`
+
+**Files:**
+- Modify: `plugin/kfxgen/converter.py` (`extract_chapters_from_oeb` spine loop; add a `_build_style_resolver` helper)
+- Test: `tests/unit/test_converter.py`
+
+**Interfaces:**
+- Consumes: `extract_blocks_from_html(element, style_resolver=...)` (Task 3).
+- Produces: a `_build_style_resolver(oeb_book, item, log) -> callable | None` helper; the spine loop passes its result into `extract_blocks_from_html`. On any failure or outside Calibre, returns `None` (so `block_style` stays `None`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+@pytest.mark.unit
+def test_style_resolver_none_outside_calibre(monkeypatch):
+    # calibre.ebooks.oeb.stylizer is absent in CI -> resolver is None
+    import logging
+    r = converter._build_style_resolver(object(), object(), logging.getLogger("t"))
+    assert r is None
+
+
+@pytest.mark.unit
+def test_chapters_carry_block_style_with_fake_stylizer(monkeypatch, simple_oeb_centered):
+    # simple_oeb_centered: an EpubAsOeb whose one spine item is
+    # <p class="c">Title</p><p>body</p> with .c { text-align:center }.
+    # Monkeypatch _build_style_resolver to a fake so the test needs no Calibre.
+    def fake_builder(oeb, item, log):
+        def resolver(elem):
+            cls = (elem.get("class") or "")
+            return {"text-align": "center"} if "c" in cls.split() else {}
+        return resolver
+
+    monkeypatch.setattr(converter, "_build_style_resolver", fake_builder)
+    import logging
+    chapters = converter.extract_chapters_from_oeb(simple_oeb_centered, logging.getLogger("t"))
+    blocks = chapters[0].get("blocks", [])
+    assert any((b.get("block_style") or {}).get("align") == "center" for b in blocks)
+```
+
+If `simple_oeb_centered` doesn't exist, build it with the same EpubBuilder/`_xhtml_page` shim used by the other `extract_chapters_from_oeb` tests; the class+CSS only needs to survive into the spine item's lxml (the fake resolver reads the `class` attribute, so no real CSS cascade is required).
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `<venv>/bin/pytest tests/unit/test_converter.py -q -k "style_resolver or block_style_with_fake"`
+Expected: FAIL (`AttributeError: _build_style_resolver`).
+
+- [ ] **Step 3: Implement**
+
+Add the helper near the top of `converter.py` (after imports). The Stylizer constructor signature was confirmed by spike (calibre 9.10.0): `Stylizer(tree, path, oeb, opts, profile=None, extra_css='', user_css='', base_css='')` — so the positional call below (`tree, path, oeb, opts, profile`) is correct. The try/except still wraps it so any cross-version drift degrades to `None` (no per-element CSS) rather than raising into the pipeline.
+
+**Anti-silent-no-op note:** because the fallback returns `None` on failure and the unit tests use a *fake* resolver, a broken real Stylizer would make Plan B a silent no-op that the unit suite cannot catch (the `EpubAsOeb` test shim has no `opts`/oeb for Stylizer, so it always yields `None`). The *only* thing that exercises the real Stylizer is a conversion through the actual Calibre pipeline — validated in Task 8 Step 4a (real-pipeline smoke). Do not consider Task 4 "working" on unit tests alone.
+
+```python
+def _build_style_resolver(oeb_book, item, log):
+    """Return a callable elem->computed-CSS-dict using Calibre's Stylizer, or
+    None when Calibre/Stylizer is unavailable or construction fails. Never
+    raises — failure degrades to no per-element block styling."""
+    try:
+        from calibre.ebooks.oeb.stylizer import Stylizer
+    except Exception:
+        return None
+    try:
+        data = getattr(item, "data", None)
+        if data is None:
+            return None
+        profile = getattr(getattr(oeb_book, "opts", None), "output_profile", None)
+        stylizer = Stylizer(
+            data, getattr(item, "href", "") or "", oeb_book,
+            getattr(oeb_book, "opts", None), profile,
+        )
+
+        def resolve(elem):
+            try:
+                st = stylizer.style(elem)
+                return {
+                    "text-align": st.get("text-align"),
+                    "text-indent": st.get("text-indent"),
+                }
+            except Exception:
+                return None
+
+        return resolve
+    except Exception as e:
+        log.warn(f"  Stylizer unavailable ({e}); skipping per-element CSS")
+        return None
+```
+
+In the spine loop where `extract_blocks_from_html(item.data)` is called (Task-3 code path), build and pass the resolver:
+
+```python
+            resolver = _build_style_resolver(oeb_book, item, log)
+            blocks = extract_blocks_from_html(item.data, style_resolver=resolver)
+            text = "\n\n".join(b["text"] for b in blocks)
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `<venv>/bin/pytest tests/unit/test_converter.py -q`
+Expected: PASS (new + existing). The no-Calibre default keeps `block_style=None`, so existing chapter tests are unchanged.
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+<venv>/bin/ruff check plugin/kfxgen/converter.py tests/unit/test_converter.py
+<venv>/bin/ruff format plugin/kfxgen/converter.py tests/unit/test_converter.py
+git add plugin/kfxgen/converter.py tests/unit/test_converter.py
+git commit -m "feat(css): Stylizer-backed style_resolver with fallback (#9)"
+```
+
+---
+
+### Task 5: `build_fragment_157` — `align` override
+
+**Files:**
+- Modify: `plugin/kfxgen/native_generator.py` (`build_fragment_157`)
+- Test: `tests/unit/test_native_generator.py`
+
+**Interfaces:**
+- Consumes: `inline_style.ALIGN_MAP` (Task 2).
+- Produces: `build_fragment_157(..., align=None)`; when `align` is a keyword in `ALIGN_MAP`, `value[IS("$34")]` is set to the mapped symbol instead of the default `$321`. `align=None` → unchanged default.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+@pytest.mark.unit
+def test_align_overrides_text_align():
+    from kfxgen.kfxlib_minimal.ion import IS
+    gen = NativeKFXGenerator()
+    assert gen.build_fragment_157(entity_name="sa", align="center").value[IS("$34")] == IS("$320")
+    assert gen.build_fragment_157(entity_name="sb", align="left").value[IS("$34")] == IS("$59")
+    assert gen.build_fragment_157(entity_name="sc", align="right").value[IS("$34")] == IS("$61")
+
+
+@pytest.mark.unit
+def test_align_default_is_justify():
+    from kfxgen.kfxlib_minimal.ion import IS
+    gen = NativeKFXGenerator()
+    assert gen.build_fragment_157(entity_name="sd").value[IS("$34")] == IS("$321")
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `<venv>/bin/pytest tests/unit/test_native_generator.py -q -k "align_overrides or align_default"`
+Expected: FAIL (`TypeError: unexpected keyword 'align'`).
+
+- [ ] **Step 3: Implement**
+
+Add `align=None` to the signature (after `italic=False`). Import the map at top of `native_generator.py` (with the other inline_style import if present, else add `from .inline_style import ALIGN_MAP`). In the value construction, the `$34` entry currently hardcodes `IS("$321")`. Replace that literal with a computed value:
+
+```python
+        # $34 = text-align; default justify ($321), overridden per element.
+        text_align = IS(ALIGN_MAP[align]) if align in ALIGN_MAP else IS("$321")
+```
+
+and use `text_align` where `IS("$321")` was in the IonStruct.
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `<venv>/bin/pytest tests/unit/test_native_generator.py -q -k "align or style or margin or bold or italic or underline or line_height"`
+Expected: PASS (new + existing style tests confirm default unchanged).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+<venv>/bin/ruff check plugin/kfxgen/native_generator.py tests/unit/test_native_generator.py
+<venv>/bin/ruff format plugin/kfxgen/native_generator.py tests/unit/test_native_generator.py
+git add plugin/kfxgen/native_generator.py tests/unit/test_native_generator.py
+git commit -m "feat(css): text-align override in build_fragment_157 (#9)"
+```
+
+---
+
+### Task 6: `build_fragment_157` — `text_indent` + padding suppression
+
+**Files:**
+- Modify: `plugin/kfxgen/native_generator.py` (`build_fragment_157`)
+- Test: `tests/unit/test_native_generator.py`
+
+**Interfaces:**
+- Produces: `build_fragment_157(..., text_indent=None)`; `text_indent` is a `(mag, unit_sym)` tuple. When set, `value[IS("$36")]` uses that magnitude+unit AND the `$47` padding-top is omitted. `text_indent=None` → `$36`=0 default and padding-top behavior unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+@pytest.mark.unit
+def test_text_indent_sets_36_and_omits_padding():
+    from kfxgen.kfxlib_minimal.ion import IS, IonDecimal
+    gen = NativeKFXGenerator()
+    frag = gen.build_fragment_157(entity_name="si", text_indent=("1.5", "$308"))
+    ind = frag.value[IS("$36")]
+    assert ind[IS("$307")] == IonDecimal("1.5")
+    assert ind[IS("$306")] == IS("$308")
+    assert IS("$47") not in frag.value  # padding-top suppressed
+
+
+@pytest.mark.unit
+def test_no_text_indent_keeps_default():
+    from kfxgen.kfxlib_minimal.ion import IS, IonDecimal
+    gen = NativeKFXGenerator()
+    frag = gen.build_fragment_157(entity_name="sj")
+    ind = frag.value[IS("$36")]
+    assert ind[IS("$307")] == IonDecimal("0")
+    assert IS("$47") in frag.value  # padding-top present by default (non-heading)
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `<venv>/bin/pytest tests/unit/test_native_generator.py -q -k "text_indent or keeps_default"`
+Expected: FAIL (`TypeError: unexpected keyword 'text_indent'`).
+
+- [ ] **Step 3: Implement**
+
+Add `text_indent=None` to the signature. The `$36` entry currently hardcodes `IonDecimal("0"), IS("$306"), IS("$314")`. Replace with a computed value:
+
+```python
+        # $36 = text-indent; default 0%, overridden per element.
+        if text_indent is not None:
+            indent_struct = IonStruct(
+                IS("$307"), IonDecimal(text_indent[0]),
+                IS("$306"), IS(text_indent[1]),
+            )
+        else:
+            indent_struct = IonStruct(
+                IS("$307"), IonDecimal("0"), IS("$306"), IS("$314")
+            )
+```
+
+and use `indent_struct` for `$36` in the IonStruct. Then guard the padding-top block: it currently is `if not is_heading: value[IS("$47")] = ...`. Change to:
+
+```python
+        # Body text gets padding-top for paragraph spacing; headings rely on
+        # margin-top. A non-zero first-line indent replaces inter-paragraph
+        # spacing (print convention), so suppress padding-top when indented.
+        if not is_heading and text_indent is None:
+            value[IS("$47")] = IonStruct(
+                IS("$307"), IonDecimal("1"), IS("$306"), IS("$310")
+            )
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `<venv>/bin/pytest tests/unit/test_native_generator.py -q -k "text_indent or keeps_default or style or margin or align"`
+Expected: PASS.
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+<venv>/bin/ruff check plugin/kfxgen/native_generator.py tests/unit/test_native_generator.py
+<venv>/bin/ruff format plugin/kfxgen/native_generator.py tests/unit/test_native_generator.py
+git add plugin/kfxgen/native_generator.py tests/unit/test_native_generator.py
+git commit -m "feat(css): text-indent + padding-top suppression in build_fragment_157 (#9)"
+```
+
+---
+
+### Task 7: Thread `block_style` through `_build_chapter_content`
+
+**Files:**
+- Modify: `plugin/kfxgen/native_generator.py` (`_build_chapter_content`: `_append_text_with_spans`, the block iteration, the title-strip first-block rebuild, and the plain-text entry-style branch)
+- Test: `tests/unit/test_native_generator.py`
+
+**Interfaces:**
+- Consumes: `chapter["blocks"][i]["block_style"]` (Tasks 3–4), `build_fragment_157(align=, text_indent=)` (Tasks 5–6), the existing `_allocate_style` cache.
+- Produces: text chunks carry `chunk["block_style"]`; each plain-text entry's `$157` is allocated with that block's `align`/`indent` (deduped). Headings/links/images unaffected. No-`block_style` chunks resolve to the existing body style (byte-stable).
+
+- [ ] **Step 1: Write the failing integration test**
+
+```python
+@pytest.mark.unit
+def test_block_style_produces_aligned_indented_157(tmp_path):
+    from kfxgen.kfxlib_minimal.ion import IS, IonDecimal
+    gen = NativeKFXGenerator()
+    chapters = [{
+        "title": "Ch",
+        "text": "centered indented line",
+        "blocks": [{
+            "text": "centered indented line", "spans": [],
+            "block_style": {"align": "center", "indent": ("2", "$308")},
+        }],
+    }]
+    gen.generate_full_book(title="T", author="A", chapters=chapters,
+                           output_path=str(tmp_path / "o.kfx"))
+    styles = [f for f in gen.fragments if str(f.ftype) == "$157"]
+    # A style must exist with text-align center, text-indent 2em, no padding-top.
+    hit = [
+        f for f in styles
+        if f.value.get(IS("$34")) == IS("$320")
+        and IS("$36") in f.value
+        and f.value[IS("$36")].get(IS("$306")) == IS("$308")
+        and IS("$47") not in f.value
+    ]
+    assert hit, "expected a centered+indented $157 with padding-top suppressed"
+```
+
+(Use `f.value.get(...)` via the IonStruct `in`/`[]` protocol; if `.get` is unavailable, write a small `g(struct,key)` helper as used in earlier tests.)
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `<venv>/bin/pytest tests/unit/test_native_generator.py -q -k block_style_produces`
+Expected: FAIL (no such style — block_style not threaded yet).
+
+- [ ] **Step 3: Carry `block_style` onto chunks**
+
+In `_append_text_with_spans` (line ~2217), add a `block_style` parameter and include it in the emitted chunk dict:
+
+```python
+        def _append_text_with_spans(chunk_text, para_text, para_spans, block_style):
+            ...
+                all_chunks.append({
+                    "type": "text", "text": piece, "spans": pspans,
+                    "block_style": block_style,
+                })
+```
+
+At the block iteration call site (line ~2326) pass it:
+
+```python
+                    para_spans = block.get("spans", [])
+                    block_style = block.get("block_style")
+                    for chunk in _emit_text_chunks(para):
+                        if chunk["type"] == "image":
+                            all_chunks.append(chunk)
+                        else:
+                            _append_text_with_spans(
+                                chunk["text"], para, para_spans, block_style
+                            )
+```
+
+In the title-strip first-block rebuild (line ~2305) carry block_style onto the replacement dict:
+
+```python
+                            iter_blocks[0] = {
+                                "text": remainder,
+                                "spans": rebased_spans,
+                                "block_style": first.get("block_style"),
+                            }
+```
+
+- [ ] **Step 4: Allocate per-chunk style from `block_style`**
+
+In the `$259` build loop's plain-text branch (the final `else` that does `entry_styles.append(story_names[ch_idx])`, line ~2561), replace with a block-style-aware allocation. (Leave the heading branch and the link branch untouched.)
+
+```python
+                else:
+                    bs = chunk.get("block_style") or {}
+                    attrs = {"font_size": chapter.get("font_size", 1.0)}
+                    if bs.get("align"):
+                        attrs["align"] = bs["align"]
+                    if bs.get("indent"):
+                        attrs["text_indent"] = bs["indent"]
+                    entry_styles.append(_allocate_style("", **attrs))
+                    entry_link_targets.append(None)
+                    entry_link_styles.append(None)
+                    entry_link_text_lengths.append(None)
+```
+
+When `bs` has neither align nor indent, `_allocate_style("", font_size=fs)` returns the same cached `body_name` as before → byte-identical. Ensure `build_fragment_157` is called by `_allocate_style` with `align`/`text_indent` kwargs (it accepts them from Tasks 5–6).
+
+- [ ] **Step 5: Run, verify pass (full generator + converter suites)**
+
+Run: `<venv>/bin/pytest tests/unit/test_native_generator.py tests/unit/test_converter.py -q`
+Expected: PASS (new integration test + all existing; defaults unchanged).
+
+- [ ] **Step 6: Lint + commit**
+
+```bash
+<venv>/bin/ruff check plugin/kfxgen/native_generator.py tests/unit/test_native_generator.py
+<venv>/bin/ruff format plugin/kfxgen/native_generator.py tests/unit/test_native_generator.py
+git add plugin/kfxgen/native_generator.py tests/unit/test_native_generator.py
+git commit -m "feat(css): thread block_style through chapter content (#9)"
+```
+
+---
+
+### Task 8: Byte-stable guard + full-suite verification
+
+**Files:**
+- Modify: `tests/unit/test_native_generator.py`
+
+**Interfaces:**
+- Consumes: the full pipeline (Tasks 1–7).
+
+- [ ] **Step 1: Add a default-stability test**
+
+```python
+@pytest.mark.unit
+def test_no_block_style_emits_default_align_and_indent(tmp_path):
+    from kfxgen.kfxlib_minimal.ion import IS, IonDecimal
+    gen = NativeKFXGenerator()
+    chapters = [{"title": "Ch", "text": "plain body text"}]  # no blocks/block_style
+    gen.generate_full_book(title="T", author="A", chapters=chapters,
+                           output_path=str(tmp_path / "o.kfx"))
+    styles = [f for f in gen.fragments if str(f.ftype) == "$157"]
+    # Every body style keeps justify ($321) and indent 0; none carry a non-% indent unit.
+    for f in styles:
+        if IS("$34") in f.value:
+            assert f.value[IS("$34")] in (IS("$321"), IS("$320"))  # justify or heading-center if any
+        if IS("$36") in f.value:
+            assert f.value[IS("$36")][IS("$306")] == IS("$314")  # default % unit, value 0
+```
+
+- [ ] **Step 2: Run the full unit suite**
+
+Run: `<venv>/bin/pytest tests/unit -q`
+Expected: PASS (all).
+
+- [ ] **Step 3: Lint repo-wide + commit**
+
+```bash
+<venv>/bin/ruff check . && <venv>/bin/ruff format --check .
+git add -A
+git commit -m "test(css): default-stability guard for typography subset (#9)"
+```
+
+- [ ] **Step 4a: Real-pipeline smoke (anti-silent-no-op gate for Task 4)**
+
+The unit tests only exercise a *fake* `style_resolver`; the `EpubAsOeb` shim
+can't drive the real Stylizer (no `opts`/oeb). This step is the only check that
+the Stylizer path actually fires. Build a small EPUB with a CSS file setting
+`p.ctr { text-align: center }` and `p.ind { text-indent: 2em }` (or inline
+`style=` attributes), convert it through the **actual plugin** (dev build via
+`build_plugin.sh --install`, then `ebook-convert in.epub out.kfx`; restore the
+merged build after), and decode `out.kfx` with `kfxlib_minimal` (reuse
+`tools/`-style loading). Assert at least one `$157` has `$34`=`$320` (center) and
+one has a non-default `$36`. If none appear, the resolver silently returned
+`None` — investigate the Stylizer construction before proceeding. (Standalone
+`create_oebbook` was found impractical for a unit test: it needs the full EPUB
+input pipeline, so this real-conversion smoke is the substitute.)
+
+- [ ] **Step 4: Gutenberg corpus regression gate (manual, not automated)**
+
+Obtain the 90-book Project Gutenberg corpus (per the README) and place/symlink it into `research/gutenberg-top-90/`. Run the Calibre-path baseline against the branch's Stylizer code (dev build or calibre-debug harness, not the installed plugin) and diff fidelity vs the committed `research/gutenberg-top-90-baseline*/BASELINE.md`. This is a content/crash gate — text-retention numbers should be unchanged; any movement or new failure flags a regression. If output legitimately changed, regenerate and commit the affected snapshot. Record the result on #9. (Not part of CI.)
+
+- [ ] **Step 5: Device verification note (release gate)**
+
+Convert an EPUB with centered text and first-line indents through the built plugin and confirm on a physical Kindle: centered paragraphs render centered, indented paragraphs show first-line indent without doubled paragraph spacing. Record on #9.
+
+---
+
+## Self-review
+
+- **Spec coverage:** text-align (Tasks 2,5,7) ✓; text-indent + padding suppression (Tasks 1,2,6,7) ✓; Stylizer + fallback (Tasks 3,4) ✓; unit mapping (Task 1) ✓; honor-all-incl-left (Task 2 keyword passthrough + Task 5 ALIGN_MAP) ✓; byte-stable defaults (Tasks 5,6,7 design + Task 8 guard) ✓; corpus + device gates (Task 8) ✓. Margins explicitly out of scope (spec) — not a gap.
+- **Placeholders:** none — every code/test step has concrete code; the one genuine unknown (Stylizer constructor signature) is called out with a probe command and a never-raises fallback.
+- **Type consistency:** `block_style = {"align": str|None, "indent": (mag,unit_sym)|None}` used identically in Tasks 2,3,4,7; `parse_css_length`/`compute_block_style`/`build_fragment_157(align=, text_indent=)`/`_build_style_resolver` signatures match across tasks; `text_indent` is always a `(mag, unit_sym)` tuple from Task 1 through Task 7.

--- a/docs/superpowers/specs/2026-06-28-css-typography-subset-design.md
+++ b/docs/superpowers/specs/2026-06-28-css-typography-subset-design.md
@@ -1,0 +1,186 @@
+# Design: CSS typography subset — text-align + text-indent (Plan B of #9)
+
+Date: 2026-06-28
+Issue: #9 (Carry inline emphasis and more CSS typography through to KFX styles)
+Status: Approved
+Predecessor: Plan A (inline emphasis) shipped in PR #19, device-verified.
+
+## Problem
+
+The native generator applies a fixed block style: `text-align: justify` and
+`text-indent: 0` on every paragraph, ignoring the source EPUB's per-element
+typography. Books lose intentional centering (titles, verse, captions) and
+first-line indentation.
+
+## Scope
+
+In:
+- per-element **text-align** (`$34`)
+- per-element **text-indent** (`$36`)
+
+Out (separate efforts):
+- **margins** — the current `build_fragment_157` margin symbols (`$46`/`$47`/`$48`)
+  contradict jhowell's authoritative catalog (`$47`=margin-top, `$48`=margin-left,
+  `$49`=margin-bottom). kfxgen's output is device-correct in its own context, so
+  adding per-element margins needs a reference-KFX symbol verification first.
+  Tracked separately.
+
+## Library survey (40 EPUBs from a personal library)
+
+- Paragraph `text-align`: 26/40 unset, 7 justify, 1 left, ~6 center (the center
+  count is mostly titlepage/cover CSS, not whole-book centering).
+- Explicit center/right on specific elements: 15/40 (38%).
+- Non-zero first-line `text-indent`: 35/40 (88%).
+
+Implications: blanket `text-align: left` is rare (1/40), so honoring source
+alignment including `left` is low-risk. First-line indent is near-universal, so
+text-indent is high-value — but it collides with kfxgen's inter-paragraph
+spacing model (see Behaviors).
+
+## Feasibility — KFX units map directly
+
+KFX's `$306` length-unit enum (from jhowell `KFX Input`/`yj_to_epub_properties.py`):
+
+| unit | symbol |
+|---|---|
+| em | `$308` |
+| rem | `$505` |
+| % | `$314` |
+| pt | `$318` |
+| px | `$319` |
+| mm | `$316` |
+| lh | `$310` |
+
+So a source CSS length becomes a KFX length by **unit mapping**, not numeric
+conversion: `1.5em` → `$307=1.5, $306=$308`. Unsupported units (`vw`, `vh`,
+`ch`, `ex`) and `auto` are dropped (no override).
+
+text-align values (confirmed, matches current code): `$320`=center,
+`$321`=justify, `$59`=left, `$61`=right.
+
+## Architecture
+
+### Data model (converter → generator)
+
+`chapter["blocks"]` entries (from Plan A: `{"text", "spans"}`) gain an optional:
+
+```python
+"block_style": {"align": str | None, "indent": (mag: str, unit_sym: str) | None}
+```
+
+`block_style` is `None` (or absent) when no source style applies or the
+resolver is unavailable. Plan A's flat `text` and the `spans` are unchanged.
+
+### Extraction (`converter.py`)
+
+- `extract_blocks_from_html(element, style_resolver=None)` gains a
+  `style_resolver` callable: `elem -> dict | None` returning that element's
+  computed CSS (at least `text-align`, `text-indent`). For each block element it
+  calls the resolver and runs `compute_block_style` to populate `block_style`.
+- `extract_chapters_from_oeb` builds a **Stylizer per spine item**
+  (`calibre.ebooks.oeb.stylizer.Stylizer`) and wraps it as the resolver. The
+  construction is behind try/except: any failure (or non-Calibre environment)
+  yields `style_resolver=None` → no `block_style` → Plan A behavior. Mirrors the
+  image-optimizer's calibre-optional pattern.
+- Synthesized/text-replaced chapters (title page, half-title, rebuilt contents)
+  already drop `blocks` (Plan A); they get no `block_style` either.
+
+### Pure helpers (`inline_style.py`, Calibre-independent, unit-tested)
+
+- `ALIGN_MAP = {"left": "$59", "right": "$61", "center": "$320", "justify": "$321"}`
+- `parse_css_length(value: str) -> tuple[str, str] | None` — parse magnitude +
+  unit, map unit to its `$306` symbol; return `None` for unsupported unit,
+  `auto`, empty, or a zero magnitude.
+- `compute_block_style(css: dict) -> dict` — read `text-align` (return the CSS
+  keyword string if it is one of left/right/center/justify, else `None`; the
+  keyword→symbol mapping happens later in `build_fragment_157`, not here) and
+  `text-indent` (via `parse_css_length`; `None` when zero/unset/unmappable).
+  Returns `{"align", "indent"}` (values may be `None`). `block_style` therefore
+  carries a human-readable align keyword and a pre-parsed `(mag, unit_sym)`
+  indent — `ALIGN_MAP` is applied only at `$157` build time.
+
+### Generation (`native_generator.py`)
+
+- `build_fragment_157` gains `align=None` and `text_indent=None`:
+  - `align` (a CSS keyword) overrides the default `$34` via `ALIGN_MAP`; when
+    `None`, keep the current `$321` default.
+  - `text_indent` (a `(mag, unit_sym)` tuple) sets `$36` to that value AND
+    **omits the `$47` padding-top** for that style; when `None`, keep `$36`=0 and
+    the existing padding-top.
+  - Both `None` → output byte-identical to today.
+- `_build_chapter_content` passes each block's `block_style` (`align`, `indent`)
+  into the existing `_allocate_style` cache so distinct combinations dedupe into
+  shared `$157` fragments and register in `extra_style_names` as today.
+
+## Behaviors
+
+- **text-align:** honor every source value including `left`; fall back to the
+  justify default only when the source specifies nothing.
+- **text-indent:** honor the source value (unit-mapped). When a paragraph's
+  indent is non-zero, suppress kfxgen's inter-paragraph `padding-top` for it
+  (print convention: first-line indent OR block spacing, not both). Zero/unset
+  indent keeps the existing spacing.
+
+## Byte-stability
+
+Books with no Stylizer, or whose paragraphs are unset / justify+zero-indent,
+produce identical output. Only books that specify other alignment or non-zero
+indent change — the feature working as intended. Guarded by a no-block-style
+stability test.
+
+## Error handling
+
+- Stylizer import/instantiation/lookup failure → resolver `None` or per-element
+  `None`; never raises. Falls back to Plan A behavior.
+- Unmappable CSS values (unsupported unit, `auto`, malformed) → omitted.
+
+## Testing
+
+- **Unit (no Calibre):** `parse_css_length` (each unit + rejects), `ALIGN_MAP`
+  via `compute_block_style` (incl. `left`, unset, unmappable),
+  `compute_block_style` indent zero/non-zero.
+- **Generator:** `build_fragment_157` with `align` (each value) and
+  `text_indent` (sets `$36`, omits `$47`); byte-stable defaults when both `None`.
+- **Extraction:** `extract_blocks_from_html` with a **fake `style_resolver`**
+  asserting `block_style` flows onto blocks; `None` resolver → no `block_style`.
+- **Integration:** a chapter with a fake resolver yielding center + indent →
+  generated KFX has a `$157` with `$34`=center and `$36`=indent and no `$47`.
+- **Stylizer real construction:** behind the fallback; probed during
+  implementation (confirm the value form Stylizer returns; unit mapping or skip
+  handles either string-with-unit or pt-resolved numbers).
+- **Gutenberg corpus regression gate (final):** run the 90-book Project
+  Gutenberg baseline and diff fidelity vs the committed
+  `research/gutenberg-top-90-baseline*/BASELINE.md` snapshots. This is a
+  **content/crash gate, not a styling check** — it measures text retention
+  (`source_chars`→`chapter_chars`→`kfx_chars`), which Plan B does not affect, so
+  the numbers should be unchanged; any movement or new failure flags an
+  unintended regression. Its real value: the Calibre-path runner is the only
+  thing that exercises the *real* Calibre Stylizer across 90 structurally-diverse
+  books (verse, multilingual, 1,169-entry TOCs, image-heavy), which the
+  fake-resolver unit tests cannot. The corpus EPUBs are not committed to this
+  public repo; obtain them (per the README's corpus instructions) and place or
+  symlink them into `research/gutenberg-top-90/` to run.
+  Exercise the branch's Stylizer code via a dev build or calibre-debug harness,
+  not the installed plugin. If Plan B intentionally changes any book's output,
+  regenerate and commit the affected baseline snapshot as a deliberate update.
+- **Device (release gate, manual):** centered/indented text renders correctly on
+  a physical Kindle.
+
+## Risks
+
+1. **Stylizer value form** varies across Calibre versions (string-with-unit vs
+   resolved pt). Mitigated: `parse_css_length` maps whatever unit appears; pt is
+   supported; unrecognized forms are skipped, never crash.
+2. **Indent/padding interaction** changes spacing on ~88% of books. Mitigated by
+   the indent-suppresses-padding rule + device verification before release.
+3. **text-align overriding the reader's Kindle justification preference** for
+   books that specify alignment — accepted (honoring source intent; consistent
+   with kfxgen already forcing justify today).
+
+## Boundary with related issues
+
+- Builds directly on Plan A's `block`/`block_style` data model and the
+  `_allocate_style` cache.
+- Margins: separate effort, gated on the `$46`/`$47`/`$48`/`$49` symbol
+  verification.
+- #20 (position-map conformance) and #21 (deferred minors) are independent.

--- a/plugin/kfxgen/converter.py
+++ b/plugin/kfxgen/converter.py
@@ -47,7 +47,7 @@ def _build_style_resolver(oeb_book, item, log):
 
         return resolve
     except Exception as e:
-        log.warn(f"  Stylizer unavailable ({e}); skipping per-element CSS")
+        log.warning(f"  Stylizer unavailable ({e}); skipping per-element CSS")
         return None
 
 

--- a/plugin/kfxgen/converter.py
+++ b/plugin/kfxgen/converter.py
@@ -16,7 +16,7 @@ from ._img_tokens import (
     IMG_TOKEN_SPACE as _IMG_TOKEN_SPACE,
 )
 from .image_optimize import optimize_images
-from .inline_style import FLAG_BOLD, FLAG_ITALIC, normalize_runs
+from .inline_style import FLAG_BOLD, FLAG_ITALIC, compute_block_style, normalize_runs
 from .native_generator import NativeKFXGenerator
 
 _ITALIC_TAGS = {"em", "i"}
@@ -83,10 +83,12 @@ def _walk_inline(elem, flags=frozenset()):
     return parts
 
 
-def extract_blocks_from_html(element):
+def extract_blocks_from_html(element, style_resolver=None):
     """Like extract_text_from_html but returns structured blocks:
-    [{"text": str, "spans": [(start, length, frozenset)]}], preserving inline
-    emphasis as spans and inline <img> as IMG tokens in `text`."""
+    [{"text": str, "spans": [(start, length, frozenset)], "block_style": dict|None}],
+    preserving inline emphasis as spans and inline <img> as IMG tokens in `text`.
+    When style_resolver is given, it is called per block element (elem -> css_dict|None)
+    and the result is passed to compute_block_style to populate block_style."""
     body = element.find(".//{http://www.w3.org/1999/xhtml}body")
     if body is None:
         body = element.find(".//body")
@@ -120,7 +122,12 @@ def extract_blocks_from_html(element):
                 continue
             text, spans = normalize_runs(_walk_inline(elem))
             if text:
-                blocks.append({"text": text, "spans": spans})
+                bstyle = None
+                if style_resolver is not None:
+                    css = style_resolver(elem)
+                    if css is not None:
+                        bstyle = compute_block_style(css)
+                blocks.append({"text": text, "spans": spans, "block_style": bstyle})
             continue
 
         # Bare <img> directly under body (rare, but exists in some EPUBs)
@@ -130,7 +137,9 @@ def extract_blocks_from_html(element):
                 continue  # already handled by the block walker above
             href = elem.get("src", "") or ""
             alt = elem.get("alt", "") or ""
-            blocks.append({"text": _make_img_token(href, alt), "spans": []})
+            blocks.append(
+                {"text": _make_img_token(href, alt), "spans": [], "block_style": None}
+            )
 
     if blocks:
         return blocks
@@ -139,7 +148,7 @@ def extract_blocks_from_html(element):
     text = body.xpath("string()")
     lines = [line.strip() for line in text.split("\n")]
     text = " ".join(line for line in lines if line)
-    return [{"text": text, "spans": []}] if text else []
+    return [{"text": text, "spans": [], "block_style": None}] if text else []
 
 
 def extract_text_from_html(element):

--- a/plugin/kfxgen/converter.py
+++ b/plugin/kfxgen/converter.py
@@ -25,6 +25,32 @@ _BOLD_TAGS = {"strong", "b"}
 _security_log = logging.getLogger(__name__ + ".security")
 
 
+def _build_style_resolver(oeb_book, item, log):
+    """Return a callable elem->computed-CSS-dict using Calibre's Stylizer, or
+    None when Calibre/Stylizer is unavailable or construction fails. Never
+    raises — failure degrades to no per-element block styling."""
+    try:
+        from calibre.ebooks.oeb.stylizer import Stylizer  # noqa: PLC0415
+
+        profile = getattr(getattr(oeb_book, "opts", None), "output_profile", None)
+        stylizer = Stylizer(item.data, item.href, oeb_book, oeb_book.opts, profile)
+
+        def resolve(elem):
+            try:
+                st = stylizer.style(elem)
+                return {
+                    "text-align": st.get("text-align"),
+                    "text-indent": st.get("text-indent"),
+                }
+            except Exception:
+                return None
+
+        return resolve
+    except Exception as e:
+        log.warn(f"  Stylizer unavailable ({e}); skipping per-element CSS")
+        return None
+
+
 def _has_real_text(text):
     """True if `text` has any non-whitespace content once IMG tokens are removed.
 
@@ -367,7 +393,8 @@ def extract_chapters_from_oeb(oeb_book, log, metadata=None):
         try:
             if not hasattr(item, "data") or item.data is None:
                 continue
-            blocks = extract_blocks_from_html(item.data)
+            resolver = _build_style_resolver(oeb_book, item, log)
+            blocks = extract_blocks_from_html(item.data, style_resolver=resolver)
             text = "\n\n".join(b["text"] for b in blocks)
         except Exception as e:
             href_for_log = getattr(item, "href", "") or "<unknown>"

--- a/plugin/kfxgen/inline_style.py
+++ b/plugin/kfxgen/inline_style.py
@@ -5,8 +5,22 @@ into whitespace-normalized text plus character spans, ready to become KFX $142
 spans. See docs/superpowers/specs/2026-06-28-inline-emphasis-css-typography-design.md.
 """
 
+import re
+
 FLAG_ITALIC = "italic"
 FLAG_BOLD = "bold"
+
+#: CSS length unit -> KFX $306 unit symbol.
+_CSS_UNIT_TO_KFX = {
+    "em": "$308",
+    "rem": "$505",
+    "%": "$314",
+    "pt": "$318",
+    "px": "$319",
+    "mm": "$316",
+}
+
+_LENGTH_RE = re.compile(r"^\s*([+-]?[0-9]*\.?[0-9]+)\s*(em|rem|%|pt|px|mm)\s*$", re.I)
 
 
 def normalize_runs(segments):
@@ -52,3 +66,28 @@ def normalize_runs(segments):
         spans.append((i, j - i, f))
         i = j
     return text_out, spans
+
+
+def parse_css_length(value):
+    """Parse a CSS length string into (magnitude_str, kfx_unit_symbol).
+
+    Returns None for empty/auto/inherit, unsupported units, or a zero
+    magnitude (no override needed). Magnitude is returned as a trimmed
+    string so the caller can hand it to IonDecimal unchanged.
+    """
+    if not value:
+        return None
+    m = _LENGTH_RE.match(value)
+    if not m:
+        return None
+    mag, unit = m.group(1), m.group(2).lower()
+    try:
+        if float(mag) == 0.0:
+            return None
+    except ValueError:
+        return None
+    # Normalize "2.0" -> "2", "1.50" -> "1.5" without forcing a float repr.
+    mag = mag.strip()
+    if "." in mag:
+        mag = mag.rstrip("0").rstrip(".")
+    return (mag, _CSS_UNIT_TO_KFX[unit])

--- a/plugin/kfxgen/inline_style.py
+++ b/plugin/kfxgen/inline_style.py
@@ -91,3 +91,23 @@ def parse_css_length(value):
     if "." in mag:
         mag = mag.rstrip("0").rstrip(".")
     return (mag, _CSS_UNIT_TO_KFX[unit])
+
+
+#: CSS text-align keyword -> KFX $34 value symbol.
+ALIGN_MAP = {"left": "$59", "right": "$61", "center": "$320", "justify": "$321"}
+
+
+def compute_block_style(css):
+    """Map a computed-CSS dict to kfxgen's block_style shape.
+
+    `css` is a mapping that supports .get(prop) returning CSS strings (e.g. a
+    Calibre Stylizer Style, or a plain dict in tests). Returns
+    {"align": <keyword or None>, "indent": <(mag, unit_sym) or None>}.
+    The align keyword is mapped to a symbol later, in build_fragment_157.
+    """
+    align = None
+    raw_align = (css.get("text-align") or "").strip().lower()
+    if raw_align in ALIGN_MAP:
+        align = raw_align
+    indent = parse_css_length(css.get("text-indent") or "")
+    return {"align": align, "indent": indent}

--- a/plugin/kfxgen/inline_style.py
+++ b/plugin/kfxgen/inline_style.py
@@ -71,9 +71,14 @@ def normalize_runs(segments):
 def parse_css_length(value):
     """Parse a CSS length string into (magnitude_str, kfx_unit_symbol).
 
-    Returns None for empty/auto/inherit, unsupported units, or a zero
-    magnitude (no override needed). Magnitude is returned as a trimmed
-    string so the caller can hand it to IonDecimal unchanged.
+    Returns None for empty/auto/inherit, unsupported units, a zero magnitude
+    (no override needed), or a NEGATIVE magnitude. Negative text-indent is a
+    hanging indent that the source pairs with a compensating margin-left; since
+    margins are out of scope, honoring the negative indent alone pulls the first
+    line off the left edge and clips leading characters (observed on Gutenberg
+    front-matter metadata lists). Dropping it falls back to the default 0 indent.
+    Magnitude is returned as a trimmed string so the caller can hand it to
+    IonDecimal unchanged.
     """
     if not value:
         return None
@@ -82,7 +87,7 @@ def parse_css_length(value):
         return None
     mag, unit = m.group(1), m.group(2).lower()
     try:
-        if float(mag) == 0.0:
+        if float(mag) <= 0.0:
             return None
     except ValueError:
         return None

--- a/plugin/kfxgen/native_generator.py
+++ b/plugin/kfxgen/native_generator.py
@@ -2236,7 +2236,7 @@ class NativeKFXGenerator:
                 pos += self.CHUNK_SIZE
             return chunks
 
-        def _append_text_with_spans(chunk_text, para_text, para_spans):
+        def _append_text_with_spans(chunk_text, para_text, para_spans, block_style):
             """Split chunk_text by CHUNK_SIZE and attach the slice of
             para_spans covering each piece, offsets rebased to the piece.
             The chunk_text is a (stripped) substring of para_text; find its
@@ -2255,7 +2255,14 @@ class NativeKFXGenerator:
                     b = min(s + length, p_end)
                     if b > a:
                         pspans.append((a - p_start, b - a, flags))
-                all_chunks.append({"type": "text", "text": piece, "spans": pspans})
+                all_chunks.append(
+                    {
+                        "type": "text",
+                        "text": piece,
+                        "spans": pspans,
+                        "block_style": block_style,
+                    }
+                )
                 pos += self.CHUNK_SIZE
 
         for ch_idx, chapter in enumerate(chapters):
@@ -2327,6 +2334,7 @@ class NativeKFXGenerator:
                                     iter_blocks[0] = {
                                         "text": remainder,
                                         "spans": rebased_spans,
+                                        "block_style": first.get("block_style"),
                                     }
                                 else:
                                     iter_blocks = iter_blocks[1:]
@@ -2341,11 +2349,14 @@ class NativeKFXGenerator:
                         if not para:
                             continue
                         para_spans = block.get("spans", [])
+                        block_style = block.get("block_style")
                         for chunk in _emit_text_chunks(para):
                             if chunk["type"] == "image":
                                 all_chunks.append(chunk)
                             else:
-                                _append_text_with_spans(chunk["text"], para, para_spans)
+                                _append_text_with_spans(
+                                    chunk["text"], para, para_spans, block_style
+                                )
 
             # Guarantee every chapter contributes at least one chunk so it
             # owns a navigable content position and the per-chapter arrays
@@ -2580,7 +2591,13 @@ class NativeKFXGenerator:
                     entry_link_styles.append(toc_link_style_names[ch_idx])
                     entry_link_text_lengths.append(len(chunk["text"]))
                 else:
-                    entry_styles.append(story_names[ch_idx])
+                    bs = chunk.get("block_style") or {}
+                    attrs = {"font_size": chapter.get("font_size", 1.0)}
+                    if bs.get("align"):
+                        attrs["align"] = bs["align"]
+                    if bs.get("indent"):
+                        attrs["text_indent"] = bs["indent"]
+                    entry_styles.append(_allocate_style("", **attrs))
                     entry_link_targets.append(None)
                     entry_link_styles.append(None)
                     entry_link_text_lengths.append(None)

--- a/plugin/kfxgen/native_generator.py
+++ b/plugin/kfxgen/native_generator.py
@@ -2592,7 +2592,7 @@ class NativeKFXGenerator:
                     entry_link_text_lengths.append(len(chunk["text"]))
                 else:
                     bs = chunk.get("block_style") or {}
-                    attrs = {"font_size": chapter.get("font_size", 1.0)}
+                    attrs = {"font_size": chapters[ch_idx].get("font_size", 1.0)}
                     if bs.get("align"):
                         attrs["align"] = bs["align"]
                     if bs.get("indent"):

--- a/plugin/kfxgen/native_generator.py
+++ b/plugin/kfxgen/native_generator.py
@@ -6,6 +6,7 @@ import posixpath
 import re
 
 from ._img_tokens import IMG_TOKEN_RE
+from .inline_style import ALIGN_MAP
 from .kfxlib_minimal.kfx_container import KfxContainer
 from .kfxlib_minimal.standard_symbols import StandardSymbolTable
 from .kfxlib_minimal.ion import IonStruct, IonDecimal, IonAnnotation, IonBLOB, IS
@@ -929,6 +930,7 @@ class NativeKFXGenerator:
         margin_top=None,
         is_heading=False,
         italic=False,
+        align=None,
     ):
         """
         Builds Fragment $157 (Style Definition).
@@ -946,6 +948,8 @@ class NativeKFXGenerator:
             bold: If True, set font-weight: bold ($13: $361)
             italic: If True, add font-style: italic ($12: $382)
             is_heading: If True, omit padding-top (headings use margin-top for spacing)
+            align: Text alignment override. If a key in ALIGN_MAP ("left", "right", "center"),
+                  use the mapped symbol; otherwise default to "justify" ($321).
 
         Returns:
             YJFragment with type $157
@@ -958,15 +962,16 @@ class NativeKFXGenerator:
         # $13 = font-weight: $350=normal, $361=bold
         font_weight = IS("$361") if bold else IS("$350")
 
+        # $34 = text-align; default justify ($321), overridden per element.
+        text_align = IS(ALIGN_MAP[align]) if align in ALIGN_MAP else IS("$321")
+
         value = IonStruct(
             IS("$48"),
             IonStruct(
                 IS("$307"), IonDecimal("0.5"), IS("$306"), IS("$314")
             ),  # margin-bottom: 0.5%
             IS("$34"),
-            IS(
-                "$321"
-            ),  # text-align: justify ($320=center, $321=justify, $59=left, $61=right)
+            text_align,  # text-align: justify ($320=center, $321=justify, $59=left, $61=right)
             IS("$36"),
             IonStruct(
                 IS("$307"), IonDecimal("0"), IS("$306"), IS("$314")

--- a/plugin/kfxgen/native_generator.py
+++ b/plugin/kfxgen/native_generator.py
@@ -931,6 +931,7 @@ class NativeKFXGenerator:
         is_heading=False,
         italic=False,
         align=None,
+        text_indent=None,
     ):
         """
         Builds Fragment $157 (Style Definition).
@@ -950,6 +951,9 @@ class NativeKFXGenerator:
             is_heading: If True, omit padding-top (headings use margin-top for spacing)
             align: Text alignment override. If a key in ALIGN_MAP ("left", "right", "center"),
                   use the mapped symbol; otherwise default to "justify" ($321).
+            text_indent: If a tuple (magnitude_str, unit_symbol), set text-indent ($36)
+                        and suppress padding-top. Default None uses 0% indent and
+                        normal padding behavior.
 
         Returns:
             YJFragment with type $157
@@ -965,6 +969,19 @@ class NativeKFXGenerator:
         # $34 = text-align; default justify ($321), overridden per element.
         text_align = IS(ALIGN_MAP[align]) if align in ALIGN_MAP else IS("$321")
 
+        # $36 = text-indent; default 0%, overridden per element.
+        if text_indent is not None:
+            indent_struct = IonStruct(
+                IS("$307"),
+                IonDecimal(text_indent[0]),
+                IS("$306"),
+                IS(text_indent[1]),
+            )
+        else:
+            indent_struct = IonStruct(
+                IS("$307"), IonDecimal("0"), IS("$306"), IS("$314")
+            )
+
         value = IonStruct(
             IS("$48"),
             IonStruct(
@@ -973,9 +990,7 @@ class NativeKFXGenerator:
             IS("$34"),
             text_align,  # text-align: justify ($320=center, $321=justify, $59=left, $61=right)
             IS("$36"),
-            IonStruct(
-                IS("$307"), IonDecimal("0"), IS("$306"), IS("$314")
-            ),  # text-indent: 0
+            indent_struct,  # text-indent
             IS("$42"),
             IonStruct(
                 IS("$307"), IonDecimal(str(line_height)), IS("$306"), IS("$310")
@@ -986,8 +1001,10 @@ class NativeKFXGenerator:
             font_weight,  # font-weight
         )
 
-        # Body text gets padding-top for paragraph spacing; headings rely on margin-top
-        if not is_heading:
+        # Body text gets padding-top for paragraph spacing; headings rely on margin-top.
+        # A non-zero first-line indent replaces inter-paragraph spacing (print convention),
+        # so suppress padding-top when indented.
+        if not is_heading and text_indent is None:
             value[IS("$47")] = IonStruct(
                 IS("$307"), IonDecimal("1"), IS("$306"), IS("$310")
             )  # padding-top: 1lh

--- a/tests/unit/test_converter.py
+++ b/tests/unit/test_converter.py
@@ -553,3 +553,29 @@ def test_chapter_carries_emphasis_blocks(simple_oeb_with_italic):
     chapters = extract_chapters_from_oeb(simple_oeb_with_italic, _silent_log())
     blocks = chapters[0]["blocks"]
     assert any(b["spans"] and b["spans"][0][2] == frozenset({I}) for b in blocks)
+
+
+# ── Task 3 (plan B/9): block_style via style_resolver ────────────────────────
+
+
+@pytest.mark.unit
+def test_blocks_block_style_from_resolver():
+    doc = _doc("<p>centered</p><p>plain</p>")  # _doc helper exists from Plan A
+
+    def resolver(elem):
+        # first <p> centered + indented, second has nothing
+        txt = "".join(elem.itertext())
+        if "centered" in txt:
+            return {"text-align": "center", "text-indent": "2em"}
+        return {}
+
+    blocks = _conv.extract_blocks_from_html(doc, style_resolver=resolver)
+    assert blocks[0]["block_style"] == {"align": "center", "indent": ("2", "$308")}
+    assert blocks[1]["block_style"] == {"align": None, "indent": None}
+
+
+@pytest.mark.unit
+def test_blocks_block_style_none_without_resolver():
+    doc = _doc("<p>x</p>")
+    blocks = _conv.extract_blocks_from_html(doc)
+    assert blocks[0]["block_style"] is None

--- a/tests/unit/test_converter.py
+++ b/tests/unit/test_converter.py
@@ -579,3 +579,52 @@ def test_blocks_block_style_none_without_resolver():
     doc = _doc("<p>x</p>")
     blocks = _conv.extract_blocks_from_html(doc)
     assert blocks[0]["block_style"] is None
+
+
+# ── Task 4: Stylizer-backed style_resolver ───────────────────────────────────
+
+
+@pytest.fixture
+def simple_oeb_centered():
+    """OEB book with one spine item containing a centered and a plain paragraph."""
+    data = _doc('<p class="c">Title</p><p>body</p>')
+
+    class _Item:
+        href = "chap.xhtml"
+        media_type = "application/xhtml+xml"
+
+    item = _Item()
+    item.data = data
+    toc = [_TOCNode("Chapter 1", "chap.xhtml")]
+    return _OEBBook(spine=[item], toc=toc)
+
+
+@pytest.mark.unit
+def test_style_resolver_none_outside_calibre():
+    # calibre.ebooks.oeb.stylizer is absent in CI -> resolver is None
+    import logging
+
+    r = _conv._build_style_resolver(object(), object(), logging.getLogger("t"))
+    assert r is None
+
+
+@pytest.mark.unit
+def test_chapters_carry_block_style_with_fake_stylizer(
+    monkeypatch, simple_oeb_centered
+):
+    # Monkeypatch _build_style_resolver to a fake so the test needs no Calibre.
+    def fake_builder(oeb, item, log):
+        def resolver(elem):
+            cls = elem.get("class") or ""
+            return {"text-align": "center"} if "c" in cls.split() else {}
+
+        return resolver
+
+    monkeypatch.setattr(_conv, "_build_style_resolver", fake_builder)
+    import logging
+
+    chapters = _conv.extract_chapters_from_oeb(
+        simple_oeb_centered, logging.getLogger("t")
+    )
+    blocks = chapters[0].get("blocks", [])
+    assert any((b.get("block_style") or {}).get("align") == "center" for b in blocks)

--- a/tests/unit/test_inline_style.py
+++ b/tests/unit/test_inline_style.py
@@ -61,3 +61,32 @@ def test_parse_css_length_rejects():
     assert ist.parse_css_length("2vw") is None
     assert ist.parse_css_length("3ch") is None
     assert ist.parse_css_length("inherit") is None
+
+
+@pytest.mark.unit
+def test_align_map_values():
+    assert ist.ALIGN_MAP == {
+        "left": "$59",
+        "right": "$61",
+        "center": "$320",
+        "justify": "$321",
+    }
+
+
+@pytest.mark.unit
+def test_compute_block_style_align():
+    assert ist.compute_block_style({"text-align": "center"})["align"] == "center"
+    assert ist.compute_block_style({"text-align": "left"})["align"] == "left"
+    assert ist.compute_block_style({"text-align": "JUSTIFY"})["align"] == "justify"
+    assert ist.compute_block_style({"text-align": "start"})["align"] is None
+    assert ist.compute_block_style({})["align"] is None
+
+
+@pytest.mark.unit
+def test_compute_block_style_indent():
+    assert ist.compute_block_style({"text-indent": "1.5em"})["indent"] == (
+        "1.5",
+        "$308",
+    )
+    assert ist.compute_block_style({"text-indent": "0"})["indent"] is None
+    assert ist.compute_block_style({})["indent"] is None

--- a/tests/unit/test_inline_style.py
+++ b/tests/unit/test_inline_style.py
@@ -61,6 +61,11 @@ def test_parse_css_length_rejects():
     assert ist.parse_css_length("2vw") is None
     assert ist.parse_css_length("3ch") is None
     assert ist.parse_css_length("inherit") is None
+    # Negative (hanging) indents are dropped — honoring them without the paired
+    # margin-left clips leading characters off the left edge (Gutenberg #9).
+    assert ist.parse_css_length("-2em") is None
+    assert ist.parse_css_length("-4em") is None
+    assert ist.parse_css_length("-0.6em") is None
 
 
 @pytest.mark.unit

--- a/tests/unit/test_inline_style.py
+++ b/tests/unit/test_inline_style.py
@@ -40,3 +40,24 @@ def test_adjacent_same_flags_merge():
     text, spans = ist.normalize_runs([("ab", frozenset({I})), ("cd", frozenset({I}))])
     assert text == "abcd"
     assert spans == [(0, 4, frozenset({I}))]
+
+
+@pytest.mark.unit
+def test_parse_css_length_units():
+    assert ist.parse_css_length("1.5em") == ("1.5", "$308")
+    assert ist.parse_css_length("2rem") == ("2", "$505")
+    assert ist.parse_css_length("5%") == ("5", "$314")
+    assert ist.parse_css_length("12pt") == ("12", "$318")
+    assert ist.parse_css_length("3px") == ("3", "$319")
+    assert ist.parse_css_length("4mm") == ("4", "$316")
+
+
+@pytest.mark.unit
+def test_parse_css_length_rejects():
+    assert ist.parse_css_length("") is None
+    assert ist.parse_css_length("auto") is None
+    assert ist.parse_css_length("0") is None
+    assert ist.parse_css_length("0em") is None
+    assert ist.parse_css_length("2vw") is None
+    assert ist.parse_css_length("3ch") is None
+    assert ist.parse_css_length("inherit") is None

--- a/tests/unit/test_native_generator.py
+++ b/tests/unit/test_native_generator.py
@@ -290,6 +290,27 @@ class TestBuildFragment157:
         gen = NativeKFXGenerator()
         assert gen.build_fragment_157(entity_name="sd").value[IS("$34")] == IS("$321")
 
+    @pytest.mark.unit
+    def test_text_indent_sets_36_and_omits_padding(self):
+        from kfxgen.kfxlib_minimal.ion import IS, IonDecimal
+
+        gen = NativeKFXGenerator()
+        frag = gen.build_fragment_157(entity_name="si", text_indent=("1.5", "$308"))
+        ind = frag.value[IS("$36")]
+        assert ind[IS("$307")] == IonDecimal("1.5")
+        assert ind[IS("$306")] == IS("$308")
+        assert IS("$47") not in frag.value  # padding-top suppressed
+
+    @pytest.mark.unit
+    def test_no_text_indent_keeps_default(self):
+        from kfxgen.kfxlib_minimal.ion import IS, IonDecimal
+
+        gen = NativeKFXGenerator()
+        frag = gen.build_fragment_157(entity_name="sj")
+        ind = frag.value[IS("$36")]
+        assert ind[IS("$307")] == IonDecimal("0")
+        assert IS("$47") in frag.value  # padding-top present by default (non-heading)
+
 
 class TestStyleSharing:
     """Issue #5: $157 styles must be shared globally, not cloned per chapter.

--- a/tests/unit/test_native_generator.py
+++ b/tests/unit/test_native_generator.py
@@ -1060,3 +1060,37 @@ def test_plain_chapter_emits_no_emphasis_fragments(tmp_path):
     )
     styles = [f for f in gen.fragments if str(f.ftype) == "$157"]
     assert all(IS("$12") not in f.value for f in styles)  # no italic anywhere
+
+
+@pytest.mark.unit
+def test_block_style_produces_aligned_indented_157(tmp_path):
+    from kfxgen.kfxlib_minimal.ion import IS
+
+    gen = NativeKFXGenerator()
+    chapters = [
+        {
+            "title": "Ch",
+            "text": "centered indented line",
+            "blocks": [
+                {
+                    "text": "centered indented line",
+                    "spans": [],
+                    "block_style": {"align": "center", "indent": ("2", "$308")},
+                }
+            ],
+        }
+    ]
+    gen.generate_full_book(
+        title="T", author="A", chapters=chapters, output_path=str(tmp_path / "o.kfx")
+    )
+    styles = [f for f in gen.fragments if str(f.ftype) == "$157"]
+    # A style must exist with text-align center, text-indent 2em, no padding-top.
+    hit = [
+        f
+        for f in styles
+        if f.value.get(IS("$34")) == IS("$320")
+        and IS("$36") in f.value
+        and f.value[IS("$36")].get(IS("$306")) == IS("$308")
+        and IS("$47") not in f.value
+    ]
+    assert hit, "expected a centered+indented $157 with padding-top suppressed"

--- a/tests/unit/test_native_generator.py
+++ b/tests/unit/test_native_generator.py
@@ -1094,3 +1094,26 @@ def test_block_style_produces_aligned_indented_157(tmp_path):
         and IS("$47") not in f.value
     ]
     assert hit, "expected a centered+indented $157 with padding-top suppressed"
+
+
+@pytest.mark.unit
+def test_no_block_style_emits_default_align_and_indent(tmp_path):
+    from kfxgen.kfxlib_minimal.ion import IS
+
+    gen = NativeKFXGenerator()
+    chapters = [{"title": "Ch", "text": "plain body text"}]  # no blocks/block_style
+    gen.generate_full_book(
+        title="T", author="A", chapters=chapters, output_path=str(tmp_path / "o.kfx")
+    )
+    styles = [f for f in gen.fragments if str(f.ftype) == "$157"]
+    # Every body style keeps justify ($321) and indent 0; none carry a non-% indent unit.
+    for f in styles:
+        if IS("$34") in f.value:
+            assert f.value[IS("$34")] in (
+                IS("$321"),
+                IS("$320"),
+            )  # justify or heading-center if any
+        if IS("$36") in f.value:
+            assert f.value[IS("$36")][IS("$306")] == IS(
+                "$314"
+            )  # default % unit, value 0

--- a/tests/unit/test_native_generator.py
+++ b/tests/unit/test_native_generator.py
@@ -268,6 +268,28 @@ class TestBuildFragment157:
         frag = gen.build_fragment_157(entity_name="s_plain")
         assert IS("$12") not in frag.value
 
+    @pytest.mark.unit
+    def test_align_overrides_text_align(self):
+        from kfxgen.kfxlib_minimal.ion import IS
+
+        gen = NativeKFXGenerator()
+        assert gen.build_fragment_157(entity_name="sa", align="center").value[
+            IS("$34")
+        ] == IS("$320")
+        assert gen.build_fragment_157(entity_name="sb", align="left").value[
+            IS("$34")
+        ] == IS("$59")
+        assert gen.build_fragment_157(entity_name="sc", align="right").value[
+            IS("$34")
+        ] == IS("$61")
+
+    @pytest.mark.unit
+    def test_align_default_is_justify(self):
+        from kfxgen.kfxlib_minimal.ion import IS
+
+        gen = NativeKFXGenerator()
+        assert gen.build_fragment_157(entity_name="sd").value[IS("$34")] == IS("$321")
+
 
 class TestStyleSharing:
     """Issue #5: $157 styles must be shared globally, not cloned per chapter.

--- a/tests/unit/test_native_generator.py
+++ b/tests/unit/test_native_generator.py
@@ -1117,3 +1117,33 @@ def test_no_block_style_emits_default_align_and_indent(tmp_path):
             assert f.value[IS("$36")][IS("$306")] == IS(
                 "$314"
             )  # default % unit, value 0
+
+
+@pytest.mark.unit
+def test_per_chapter_font_size_not_leaked_from_last_chapter(tmp_path):
+    """Regression: plain-text block-style path must use each chapter's own
+    font_size, not the leaked final chapter's value from an earlier loop."""
+    from kfxgen.kfxlib_minimal.ion import IS, IonDecimal
+
+    gen = NativeKFXGenerator()
+    chapters = [
+        {"title": "Copyright", "text": "c 2026 Author", "font_size": 0.75},
+        {"title": "Chapter One", "text": "The main body text begins here."},
+    ]
+    gen.generate_full_book(
+        title="T", author="A", chapters=chapters, output_path=str(tmp_path / "o.kfx")
+    )
+    styles = [f for f in gen.fragments if str(f.ftype) == "$157"]
+    # The first chapter has font_size=0.75 (non-default), so at least one $157
+    # must carry $16 with $307=0.75 and $306=$505 (rem unit).
+    small_styles = [
+        f
+        for f in styles
+        if IS("$16") in f.value
+        and f.value[IS("$16")].get(IS("$307")) == IonDecimal("0.75")
+        and f.value[IS("$16")].get(IS("$306")) == IS("$505")
+    ]
+    assert small_styles, (
+        "expected a $157 with font_size=0.75rem for the first chapter; "
+        "got none — leaked-loop-variable bug may still be present"
+    )


### PR DESCRIPTION
Implements **Plan B of #9** — carry per-element `text-align` and `text-indent` from the source EPUB into KFX styles. Builds on Plan A's `block`/`block_style` model. **Margins are out of scope** (their `$46`/`$47`/`$48` symbol mapping needs a reference-KFX verification first — separate effort).

## Approach

- **Pure helpers** (`inline_style.py`): `parse_css_length` (CSS length → KFX unit symbol — em/rem/%/pt/px/mm map directly), `ALIGN_MAP`, `compute_block_style`.
- **Converter**: `_build_style_resolver` builds a Calibre `Stylizer` per spine item (confirmed signature `Stylizer(tree, path, oeb, opts, profile)`), wrapped so any failure / non-Calibre env degrades to `None`. `extract_blocks_from_html` attaches `block_style` per block.
- **Generator**: `build_fragment_157` overrides `$34` (align) and `$36` (indent), and suppresses `$47` padding-top when a paragraph is indented (print convention). `_build_chapter_content` threads `block_style` through the existing `_allocate_style` cache.

## Behaviors

- Honor every source alignment incl. `left`; fall back to justify only when source is unset (library survey: blanket-left is rare).
- Non-zero first-line indent suppresses inter-paragraph spacing.

## Correctness / verification

- **Byte-stable defaults**: unstyled / no-Stylizer / justify+zero-indent books produce unchanged output (guarded by tests).
- Final whole-branch review caught and fixed a Critical (a leaked-loop-variable `font_size` bug that misapplied per-chapter font sizes) — fixed with a multi-chapter regression test.
- **Real-Stylizer smoke**: the actual Calibre Stylizer driven through branch code produced correct centered/right/indented `$157` styles — closes the silent-no-op risk the fake-resolver unit tests can't (the spike-confirmed concern in Task 4).
- 383 unit tests pass; `ruff check` + `ruff format --check` clean.

## Not covered

- Margins (separate effort); **Gutenberg corpus** content/crash gate and **physical-Kindle** visual verification remain manual (the unit tests use a fake resolver by necessity).
- Deferred Minors: redundant `mag.strip()`; bare-`<img>` `block_style=None` lacks a comment; title-strip first-block minimal-dict rebuild.

Spec: `docs/superpowers/specs/2026-06-28-css-typography-subset-design.md`
Plan: `docs/superpowers/plans/2026-06-28-css-typography.md`

Partially addresses #9 (CSS subset); does NOT auto-close it (margins remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)