### PR TITLE
chore: clean up deferred Plan A minors (#21)

### DIFF
--- a/plugin/kfxgen/inline_style.py
+++ b/plugin/kfxgen/inline_style.py
@@ -23,7 +23,9 @@ _CSS_UNIT_TO_KFX = {
 _LENGTH_RE = re.compile(r"^\s*([+-]?[0-9]*\.?[0-9]+)\s*(em|rem|%|pt|px|mm)\s*$", re.I)
 
 
-def normalize_runs(segments):
+def normalize_runs(
+    segments: list[tuple[str, frozenset]],
+) -> tuple[str, list[tuple[int, int, frozenset]]]:
     """Collapse whitespace across (text, flags) segments and return
     (normalized_text, spans). Mirrors the converter's existing
     `" ".join(text.split())` rule: each run of ASCII whitespace becomes a

--- a/plugin/kfxgen/native_generator.py
+++ b/plugin/kfxgen/native_generator.py
@@ -1136,22 +1136,19 @@ class NativeKFXGenerator:
         """
         Builds Fragment $259 (Storyline / Flow Map)
 
-        Phase 3: emits a nested $146 tree matching Calibre's KFX Output shape:
+        Emits a FLAT $146 list — one entry per chunk, directly under the
+        storyline:
 
             $259.value.$146 = [
-              { $155: outer_position, $157: outer_style, $159: $269,
-                $146: [
-                  { $155: pos[0], $157: story[0], $790: 1, ..., $145: ... },
-                  { $155: pos[1], $157: story[1],         ..., $145: ... },
-                  ...
-                ]
-              }
+              { $155: pos[0], $157: story[0], $790: 1, ..., $145: ... },
+              { $155: pos[1], $157: story[1],         ..., $145: ... },
+              ...
             ]
 
-        The single outer entry wraps all chunks as nested children. Kindle's
-        reflow groups nested children into one paragraph rendering box, which
-        is what makes glossary definitions render on separate lines without
-        the disabled $269->$270 patch.
+        (A nested single-outer-wrapper shape was tried during the Phase-3 work
+        but reverted; the flat shape is what ships and is device-verified. The
+        `outer_position` / `outer_style` params are retained for compatibility
+        but are not emitted in the flat shape.)
 
         Args:
             story_names: List of $157 fragment local symbol names per chunk.
@@ -2240,10 +2237,22 @@ class NativeKFXGenerator:
             """Split chunk_text by CHUNK_SIZE and attach the slice of
             para_spans covering each piece, offsets rebased to the piece.
             The chunk_text is a (stripped) substring of para_text; find its
-            offset once, then translate spans."""
+            offset once, then translate spans.
+
+            The CHUNK_SIZE loop below is NOT redundant: chunk_text is a whole
+            paragraph segment from _emit_text_chunks (split only on image
+            tokens, not length), so a long paragraph arrives > CHUNK_SIZE and
+            must be split here — this absorbs the old _split_long_text path.
+            """
+            # find() returns the FIRST occurrence. In the rare case of two
+            # identical text segments around an inline image in one paragraph,
+            # the second segment's spans could rebase to the first's offset.
+            # Low impact (needs emphasis + duplicate segment text + inline img);
+            # tracked in #21. Defensive base=0 means emphasis just won't apply
+            # to a chunk whose text can't be located.
             base = para_text.find(chunk_text)
             if base < 0:
-                base = 0  # defensive: emphasis simply won't apply to this chunk
+                base = 0
             pos = 0
             while pos < len(chunk_text):
                 piece = chunk_text[pos : pos + self.CHUNK_SIZE]

--- a/tests/unit/test_converter.py
+++ b/tests/unit/test_converter.py
@@ -533,6 +533,15 @@ def test_blocks_capture_bold_and_nested():
 
 
 @pytest.mark.unit
+def test_blocks_capture_b_tag():
+    # <b> maps to bold the same as <strong> (the <i>/<b> counterparts of
+    # <em>/<strong>).
+    blocks = _conv.extract_blocks_from_html(_doc("<p>a <b>bee</b> c</p>"))
+    assert blocks[0]["text"] == "a bee c"
+    assert blocks[0]["spans"] == [(2, 3, frozenset({Bf}))]
+
+
+@pytest.mark.unit
 def test_extract_text_unchanged_delegates_to_blocks():
     doc = _doc("<p>one</p><p>two <i>three</i></p>")
     assert _conv.extract_text_from_html(doc) == "one\n\ntwo three"

--- a/tests/unit/test_html_extraction_fuzz.py
+++ b/tests/unit/test_html_extraction_fuzz.py
@@ -1,7 +1,7 @@
 """
 Property-based fuzz for HTML text extraction (#124 / G2).
 
-`extract_text_from_html` and its recursive helper `_walk_paragraph_with_imgs`
+`extract_text_from_html` and its recursive helper `_walk_inline`
 walk attacker-controlled OEB element trees (the parsed XHTML of an EPUB spine
 item). The existing tests cover hand-picked shapes; nothing fuzzed malformed or
 adversarial trees.
@@ -14,7 +14,7 @@ Recursion bound (why this is safe, documented not fixed): the real attack
 surface is *parsed* XHTML bytes, and lxml caps document nesting at 256
 (`XMLSyntaxError: Excessive depth in document`) at parse time — before
 `extract_text_from_html` ever runs. 256 frames is well under Python's 1000
-recursion limit, so `_walk_paragraph_with_imgs` recursion cannot be driven to a
+recursion limit, so `_walk_inline` recursion cannot be driven to a
 RecursionError by attacker bytes. This test builds trees within that realistic
 bound. (A directly-constructed >256-deep tree is not reachable from EPUB input,
 so it is out of the threat model.)
@@ -39,7 +39,7 @@ _XHTML = "{http://www.w3.org/1999/xhtml}"
 
 # Tags the extractor branches on: block-level (paragraph boundaries), inline
 # (recursed through), and img (token path). Mixing all three exercises every
-# branch of extract_text_from_html / _walk_paragraph_with_imgs.
+# branch of extract_text_from_html / _walk_inline.
 _BLOCK_TAGS = ["p", "div", "h1", "h2", "blockquote", "li", "section", "figure"]
 _INLINE_TAGS = ["span", "b", "i", "em", "a", "strong"]
 

--- a/tests/unit/test_inline_style.py
+++ b/tests/unit/test_inline_style.py
@@ -43,6 +43,25 @@ def test_adjacent_same_flags_merge():
 
 
 @pytest.mark.unit
+def test_adjacent_differing_flags_stay_separate():
+    text, spans = ist.normalize_runs([("a", frozenset({I})), ("b", frozenset({B}))])
+    assert text == "ab"
+    assert spans == [(0, 1, frozenset({I})), (1, 1, frozenset({B}))]
+
+
+@pytest.mark.unit
+def test_collapsed_space_between_same_flag_segments_fragments():
+    # A bare (unstyled) space segment between two italic segments collapses to
+    # one space that carries its own (empty) flags, so the two italic runs do
+    # NOT merge — they fragment into two spans around the unstyled space.
+    text, spans = ist.normalize_runs(
+        [("a", frozenset({I})), (" ", frozenset()), ("b", frozenset({I}))]
+    )
+    assert text == "a b"
+    assert spans == [(0, 1, frozenset({I})), (2, 1, frozenset({I}))]
+
+
+@pytest.mark.unit
 def test_parse_css_length_units():
     assert ist.parse_css_length("1.5em") == ("1.5", "$308")
     assert ist.parse_css_length("2rem") == ("2", "$505")

--- a/tests/unit/test_native_generator.py
+++ b/tests/unit/test_native_generator.py
@@ -206,6 +206,8 @@ class TestPerParagraphChunking:
 class TestBuildFragment157:
     """Test style fragment building."""
 
+    pytestmark = pytest.mark.unit
+
     def test_default_line_height(self):
         gen = NativeKFXGenerator()
         from kfxgen.kfxlib_minimal.ion import IS, IonDecimal
@@ -268,7 +270,6 @@ class TestBuildFragment157:
         frag = gen.build_fragment_157(entity_name="s_plain")
         assert IS("$12") not in frag.value
 
-    @pytest.mark.unit
     def test_align_overrides_text_align(self):
         from kfxgen.kfxlib_minimal.ion import IS
 
@@ -283,14 +284,12 @@ class TestBuildFragment157:
             IS("$34")
         ] == IS("$61")
 
-    @pytest.mark.unit
     def test_align_default_is_justify(self):
         from kfxgen.kfxlib_minimal.ion import IS
 
         gen = NativeKFXGenerator()
         assert gen.build_fragment_157(entity_name="sd").value[IS("$34")] == IS("$321")
 
-    @pytest.mark.unit
     def test_text_indent_sets_36_and_omits_padding(self):
         from kfxgen.kfxlib_minimal.ion import IS, IonDecimal
 
@@ -301,7 +300,6 @@ class TestBuildFragment157:
         assert ind[IS("$306")] == IS("$308")
         assert IS("$47") not in frag.value  # padding-top suppressed
 
-    @pytest.mark.unit
     def test_no_text_indent_keeps_default(self):
         from kfxgen.kfxlib_minimal.ion import IS, IonDecimal
 


### PR DESCRIPTION
Addresses the deferred Minor findings from the inline-emphasis work (#21).

- **`normalize_runs`**: added type annotations.
- **`build_fragment_259` docstring**: rewritten — it described the nested Phase-3 shape that was reverted; the code emits the flat shape.
- **`_append_text_with_spans`**: documented that the `CHUNK_SIZE` loop is **not** redundant (it splits paragraph segments > `CHUNK_SIZE` from `_emit_text_chunks`), and documented the `find()`-first-occurrence limitation for duplicate segments around an inline image.
- **Tests**: added `<b>`-only, adjacent-differing-flags, and collapsed-space-fragmentation cases.
- **Fuzz test**: fixed stale `_walk_paragraph_with_imgs` references (renamed to `_walk_inline`).
- **`TestBuildFragment157`**: added class-level `pytestmark = pytest.mark.unit` and dropped the redundant per-method markers (confirmed reachable via `-m unit`).

**One item not applied as written:** the "redundant `CHUNK_SIZE` loop" item was found **invalid** on inspection — the loop is load-bearing for paragraphs longer than `CHUNK_SIZE` (segments from `_emit_text_chunks` are split only on image tokens, not length). Removing it would break long-paragraph chunking, so it's documented instead.

No behavior change (docstrings/comments/annotations/tests/markers only). 386 unit tests pass; `ruff check` + `ruff format --check` clean.

Closes #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)