### PR TITLE
chore: clean up deferred Plan B minors (#24)

### DIFF
--- a/plugin/kfxgen/converter.py
+++ b/plugin/kfxgen/converter.py
@@ -163,6 +163,8 @@ def extract_blocks_from_html(element, style_resolver=None):
                 continue  # already handled by the block walker above
             href = elem.get("src", "") or ""
             alt = elem.get("alt", "") or ""
+            # block_style is intentionally None: a bare image carries no text
+            # block-style (align/indent), so the resolver is not consulted here.
             blocks.append(
                 {"text": _make_img_token(href, alt), "spans": [], "block_style": None}
             )

--- a/plugin/kfxgen/inline_style.py
+++ b/plugin/kfxgen/inline_style.py
@@ -94,7 +94,7 @@ def parse_css_length(value):
     except ValueError:
         return None
     # Normalize "2.0" -> "2", "1.50" -> "1.5" without forcing a float repr.
-    mag = mag.strip()
+    # (mag has no surrounding whitespace — the regex group excludes it.)
     if "." in mag:
         mag = mag.rstrip("0").rstrip(".")
     return (mag, _CSS_UNIT_TO_KFX[unit])

--- a/plugin/kfxgen/native_generator.py
+++ b/plugin/kfxgen/native_generator.py
@@ -2340,10 +2340,13 @@ class NativeKFXGenerator:
                                             (start, end - start, flags)
                                         )
                                 if remainder:
+                                    # Copy-and-override so any other keys on the
+                                    # block dict (e.g. block_style, future keys)
+                                    # are forwarded, not silently dropped.
                                     iter_blocks[0] = {
+                                        **first,
                                         "text": remainder,
                                         "spans": rebased_spans,
-                                        "block_style": first.get("block_style"),
                                     }
                                 else:
                                     iter_blocks = iter_blocks[1:]


### PR DESCRIPTION
Addresses the deferred Minor findings from the CSS typography work (#24).

- **`parse_css_length`**: dropped the redundant `mag.strip()` (the regex capture group already excludes surrounding whitespace).
- **`extract_blocks_from_html`**: added a comment explaining the bare-`<img>` block sets `block_style=None` deliberately (an image carries no text block-style).
- **`_build_chapter_content` title-strip**: rebuild the first block via copy-and-override (`{**first, ...}`) so `block_style` and any future block-dict keys are forwarded rather than silently dropped.

No behavior change on current data. 386 unit tests pass; `ruff check` + `ruff format --check` clean.

Closes #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)