### PR TITLE
CSS block margins: margin-left + margin-right (Plan C of #9)

### DIFF
--- a/docs/superpowers/plans/2026-06-29-block-margins.md
+++ b/docs/superpowers/plans/2026-06-29-block-margins.md
@@ -1,0 +1,397 @@
+# Block Horizontal Margins Implementation Plan (Plan C of #9)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Carry per-element `margin-left` and `margin-right` from the source EPUB through to KFX block styles (blockquotes, indented blocks), via Calibre's Stylizer with the existing graceful fallback.
+
+**Architecture:** Extends Plan B's `block_style` machinery. `compute_block_style` reads two more CSS props; the Stylizer resolver returns them; `build_fragment_157` overrides `$48` (margin-left) and emits `$50` (margin-right); `_build_chapter_content` threads them through the existing `_allocate_style` cache.
+
+**Tech Stack:** Python 3.13, pytest, lxml/Calibre OEB + Stylizer, vendored `kfxlib_minimal`.
+
+## Global Constraints
+
+- Python via the repo venv at `/private/tmp/claude-501/-Users-justin-GitHub-kfxgen-public/0a357a5c-3454-41ea-a7c4-2fcc79a97b37/scratchpad/venv/bin`; never bare `python`.
+- Lint gate: BOTH `ruff check .` and `ruff format --check .`, pinned **ruff==0.15.1**. Run both before every commit.
+- KFX symbols (authoritative): margin-left = `$48`, margin-right = `$50`. Length units: em=`$308`, rem=`$505`, %=`$314`, pt=`$318`, px=`$319`, mm=`$316`.
+- `parse_css_length` (already present) returns `(mag, unit_sym)` or `None`; it already rejects negative/zero magnitudes and unsupported units — reuse it (negative margins must NOT be applied).
+- `block_style` carries pre-parsed `(mag, unit_sym)` tuples for margins (same shape as `indent`).
+- **Byte-stable defaults:** with no source margins, output is identical to today — `$48` stays `0.5`/`$314`, no `$50`. Do not change the existing defaults.
+- margin-top (`$47`), margin-bottom (`$49`), and padding are OUT of scope.
+
+---
+
+### Task 1: `compute_block_style` reads margin-left / margin-right
+
+**Files:**
+- Modify: `plugin/kfxgen/inline_style.py` (`compute_block_style`)
+- Test: `tests/unit/test_inline_style.py`
+
+**Interfaces:**
+- Consumes: `parse_css_length` (existing).
+- Produces: `compute_block_style(css)` now returns `{"align", "indent", "margin_left", "margin_right"}`; the two new keys are `(mag, unit_sym)` tuples or `None`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+@pytest.mark.unit
+def test_compute_block_style_margins():
+    bs = ist.compute_block_style({"margin-left": "2em", "margin-right": "1em"})
+    assert bs["margin_left"] == ("2", "$308")
+    assert bs["margin_right"] == ("1", "$308")
+
+
+@pytest.mark.unit
+def test_compute_block_style_margins_absent_and_negative():
+    bs = ist.compute_block_style({})
+    assert bs["margin_left"] is None and bs["margin_right"] is None
+    # negative margins are dropped (no clipping), like negative indent
+    bs2 = ist.compute_block_style({"margin-left": "-3em"})
+    assert bs2["margin_left"] is None
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `<venv>/bin/pytest tests/unit/test_inline_style.py -q -k compute_block_style_margins`
+Expected: FAIL (`KeyError: 'margin_left'`).
+
+- [ ] **Step 3: Implement**
+
+In `compute_block_style`, add the two reads and include them in the returned dict:
+
+```python
+def compute_block_style(css):
+    """Map a computed-CSS dict to kfxgen's block_style shape.
+
+    `css` is a mapping that supports .get(prop) returning CSS strings (e.g. a
+    Calibre Stylizer Style, or a plain dict in tests). Returns
+    {"align": <keyword or None>, "indent"/"margin_left"/"margin_right":
+    <(mag, unit_sym) or None>}. The align keyword is mapped to a symbol later,
+    in build_fragment_157.
+    """
+    align = None
+    raw_align = (css.get("text-align") or "").strip().lower()
+    if raw_align in ALIGN_MAP:
+        align = raw_align
+    indent = parse_css_length(css.get("text-indent") or "")
+    margin_left = parse_css_length(css.get("margin-left") or "")
+    margin_right = parse_css_length(css.get("margin-right") or "")
+    return {
+        "align": align,
+        "indent": indent,
+        "margin_left": margin_left,
+        "margin_right": margin_right,
+    }
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `<venv>/bin/pytest tests/unit/test_inline_style.py -q`
+Expected: PASS (new + existing).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+<venv>/bin/ruff check plugin/kfxgen/inline_style.py tests/unit/test_inline_style.py
+<venv>/bin/ruff format plugin/kfxgen/inline_style.py tests/unit/test_inline_style.py
+git add plugin/kfxgen/inline_style.py tests/unit/test_inline_style.py
+git commit -m "feat(css): compute_block_style reads margin-left/right (#9)"
+```
+
+---
+
+### Task 2: `build_fragment_157` — `margin_left` override + `margin_right` emit
+
+**Files:**
+- Modify: `plugin/kfxgen/native_generator.py` (`build_fragment_157`)
+- Test: `tests/unit/test_native_generator.py`
+
+**Interfaces:**
+- Produces: `build_fragment_157(..., margin_left=None, margin_right=None)`. `margin_left` (a `(mag, unit_sym)` tuple) overrides the default `$48` (0.5%/`$314`); `margin_right` (tuple) emits `$50`. Both `None` → byte-identical to today (`$48`=0.5%, no `$50`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+    def test_margin_left_overrides_48(self):
+        from kfxgen.kfxlib_minimal.ion import IS, IonDecimal
+        gen = NativeKFXGenerator()
+        frag = gen.build_fragment_157(entity_name="sml", margin_left=("2", "$308"))
+        ml = frag.value[IS("$48")]
+        assert ml[IS("$307")] == IonDecimal("2")
+        assert ml[IS("$306")] == IS("$308")
+
+    def test_margin_right_emits_50(self):
+        from kfxgen.kfxlib_minimal.ion import IS, IonDecimal
+        gen = NativeKFXGenerator()
+        frag = gen.build_fragment_157(entity_name="smr", margin_right=("1", "$308"))
+        mr = frag.value[IS("$50")]
+        assert mr[IS("$307")] == IonDecimal("1")
+        assert mr[IS("$306")] == IS("$308")
+
+    def test_margins_default_byte_stable(self):
+        from kfxgen.kfxlib_minimal.ion import IS, IonDecimal
+        gen = NativeKFXGenerator()
+        frag = gen.build_fragment_157(entity_name="smd")
+        ml = frag.value[IS("$48")]
+        assert ml[IS("$307")] == IonDecimal("0.5")
+        assert ml[IS("$306")] == IS("$314")
+        assert IS("$50") not in frag.value
+```
+
+(These are methods of `TestBuildFragment157`, which carries a class-level `pytestmark = pytest.mark.unit`.)
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `<venv>/bin/pytest tests/unit/test_native_generator.py -q -k "margin_left_overrides or margin_right_emits or margins_default_byte"`
+Expected: FAIL (`TypeError: unexpected keyword 'margin_left'`).
+
+- [ ] **Step 3: Implement**
+
+Add `margin_left=None, margin_right=None` to the signature (after `text_indent=None`). The `$48` entry currently hardcodes `IonStruct(IS("$307"), IonDecimal("0.5"), IS("$306"), IS("$314"))`. Compute it conditionally before the `value = IonStruct(...)` construction (mirroring `indent_struct`):
+
+```python
+        # $48 = margin-left; default 0.5%, overridden per element.
+        if margin_left is not None:
+            margin_left_struct = IonStruct(
+                IS("$307"), IonDecimal(margin_left[0]),
+                IS("$306"), IS(margin_left[1]),
+            )
+        else:
+            margin_left_struct = IonStruct(
+                IS("$307"), IonDecimal("0.5"), IS("$306"), IS("$314")
+            )
+```
+
+Use `margin_left_struct` in place of the inline `$48` value in the `value = IonStruct(...)`. Then after the value is built (near the other conditional `value[IS(...)] = ...` blocks), add:
+
+```python
+        # $50 = margin-right; emitted only when the source specifies it.
+        if margin_right is not None:
+            value[IS("$50")] = IonStruct(
+                IS("$307"), IonDecimal(margin_right[0]),
+                IS("$306"), IS(margin_right[1]),
+            )
+```
+
+- [ ] **Step 4: Run, verify pass**
+
+Run: `<venv>/bin/pytest tests/unit/test_native_generator.py -q -k "margin or style or align or text_indent or bold or italic"`
+Expected: PASS (new + existing style tests confirm defaults unchanged).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+<venv>/bin/ruff check plugin/kfxgen/native_generator.py tests/unit/test_native_generator.py
+<venv>/bin/ruff format plugin/kfxgen/native_generator.py tests/unit/test_native_generator.py
+git add plugin/kfxgen/native_generator.py tests/unit/test_native_generator.py
+git commit -m "feat(css): margin-left override + margin-right in build_fragment_157 (#9)"
+```
+
+---
+
+### Task 3: Stylizer resolver returns margin-left / margin-right
+
+**Files:**
+- Modify: `plugin/kfxgen/converter.py` (`_build_style_resolver`'s `resolve` closure)
+- Test: `tests/unit/test_converter.py`
+
+**Interfaces:**
+- Produces: the resolver's returned css dict now includes `margin-left` and `margin-right` (so the real Stylizer path provides them to `compute_block_style`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+@pytest.mark.unit
+def test_blocks_block_style_margins_from_resolver():
+    doc = _doc("<blockquote>quoted</blockquote><p>plain</p>")
+
+    def resolver(elem):
+        txt = "".join(elem.itertext())
+        if "quoted" in txt:
+            return {"margin-left": "2em", "margin-right": "1em"}
+        return {}
+
+    blocks = _conv.extract_blocks_from_html(doc, style_resolver=resolver)
+    assert blocks[0]["block_style"]["margin_left"] == ("2", "$308")
+    assert blocks[0]["block_style"]["margin_right"] == ("1", "$308")
+    assert blocks[1]["block_style"]["margin_left"] is None
+```
+
+(`blockquote` is already in `extract_blocks_from_html`'s block-tag set.)
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `<venv>/bin/pytest tests/unit/test_converter.py -q -k block_style_margins`
+Expected: FAIL (`KeyError: 'margin_left'` — Task 1 must be merged first; the resolver test here exercises `compute_block_style` via `extract_blocks_from_html`, so this passes once Task 1 lands and only needs the resolver change for the REAL Stylizer path).
+
+- [ ] **Step 3: Implement**
+
+In `_build_style_resolver`, extend the `resolve` closure's returned dict:
+
+```python
+        def resolve(elem):
+            try:
+                st = stylizer.style(elem)
+                return {
+                    "text-align": st.get("text-align"),
+                    "text-indent": st.get("text-indent"),
+                    "margin-left": st.get("margin-left"),
+                    "margin-right": st.get("margin-right"),
+                }
+            except Exception:
+                return None
+```
+
+(The test above uses a fake resolver, so it validates the extraction→compute path; this change wires the REAL Stylizer to supply margins — verified in Task 5's real-Stylizer smoke.)
+
+- [ ] **Step 4: Run, verify pass (full converter suite)**
+
+Run: `<venv>/bin/pytest tests/unit/test_converter.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+<venv>/bin/ruff check plugin/kfxgen/converter.py tests/unit/test_converter.py
+<venv>/bin/ruff format plugin/kfxgen/converter.py tests/unit/test_converter.py
+git add plugin/kfxgen/converter.py tests/unit/test_converter.py
+git commit -m "feat(css): Stylizer resolver returns margin-left/right (#9)"
+```
+
+---
+
+### Task 4: Thread margins through `_build_chapter_content`
+
+**Files:**
+- Modify: `plugin/kfxgen/native_generator.py` (`_build_chapter_content` plain-text entry branch)
+- Test: `tests/unit/test_native_generator.py`
+
+**Interfaces:**
+- Consumes: `chunk["block_style"]["margin_left"]`/`["margin_right"]` (Tasks 1,3), `build_fragment_157(margin_left=, margin_right=)` (Task 2), the `_allocate_style` cache.
+- Produces: plain-text entries whose block has margins get a `$157` allocated with those margins (deduped). No-margin chunks resolve to the same cached style as before (byte-stable).
+
+- [ ] **Step 1: Write the failing integration test**
+
+```python
+def test_block_margin_left_produces_overridden_48(tmp_path):
+    from kfxgen.kfxlib_minimal.ion import IS, IonDecimal
+    gen = NativeKFXGenerator()
+    chapters = [{
+        "title": "Ch",
+        "text": "quoted line",
+        "blocks": [{
+            "text": "quoted line", "spans": [],
+            "block_style": {"align": None, "indent": None,
+                            "margin_left": ("2", "$308"), "margin_right": None},
+        }],
+    }]
+    gen.generate_full_book(title="T", author="A", chapters=chapters,
+                           output_path=str(tmp_path / "o.kfx"))
+    styles = [f for f in gen.fragments if str(f.ftype) == "$157"]
+    hit = [
+        f for f in styles
+        if IS("$48") in f.value
+        and f.value[IS("$48")].get(IS("$307")) == IonDecimal("2")
+        and f.value[IS("$48")].get(IS("$306")) == IS("$308")
+    ]
+    assert hit, "expected a $157 with margin-left overridden to 2em"
+```
+
+(This is a module-level function — add `@pytest.mark.unit` above it, matching the other module-level integration tests. Use a `g(struct, key)` helper if IonStruct lacks `.get`, as in earlier tests.)
+
+- [ ] **Step 2: Run, verify fail**
+
+Run: `<venv>/bin/pytest tests/unit/test_native_generator.py -q -k block_margin_left_produces`
+Expected: FAIL (no overridden `$48` — margins not threaded).
+
+- [ ] **Step 3: Implement**
+
+In the plain-text entry branch (the `bs = chunk.get("block_style") or {}` block, ~line 2606), add the two margin attrs:
+
+```python
+                    bs = chunk.get("block_style") or {}
+                    attrs = {"font_size": chapters[ch_idx].get("font_size", 1.0)}
+                    if bs.get("align"):
+                        attrs["align"] = bs["align"]
+                    if bs.get("indent"):
+                        attrs["text_indent"] = bs["indent"]
+                    if bs.get("margin_left"):
+                        attrs["margin_left"] = bs["margin_left"]
+                    if bs.get("margin_right"):
+                        attrs["margin_right"] = bs["margin_right"]
+                    entry_styles.append(_allocate_style("", **attrs))
+```
+
+When no margins are present, `attrs` is unchanged from Plan B → same cached style → byte-stable.
+
+- [ ] **Step 4: Run, verify pass (full generator + converter suites)**
+
+Run: `<venv>/bin/pytest tests/unit/test_native_generator.py tests/unit/test_converter.py -q`
+Expected: PASS (new integration test + all existing; defaults unchanged).
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+<venv>/bin/ruff check plugin/kfxgen/native_generator.py tests/unit/test_native_generator.py
+<venv>/bin/ruff format plugin/kfxgen/native_generator.py tests/unit/test_native_generator.py
+git add plugin/kfxgen/native_generator.py tests/unit/test_native_generator.py
+git commit -m "feat(css): thread block margins through chapter content (#9)"
+```
+
+---
+
+### Task 5: Byte-stable guard + verification gates
+
+**Files:**
+- Modify: `tests/unit/test_native_generator.py`
+
+**Interfaces:**
+- Consumes: the full pipeline (Tasks 1–4).
+
+- [ ] **Step 1: Extend the default-stability test**
+
+Add a guard asserting that an unstyled book keeps `$48`=0.5%/`$314` and emits no `$50`:
+
+```python
+def test_no_block_style_keeps_default_margins(tmp_path):
+    from kfxgen.kfxlib_minimal.ion import IS, IonDecimal
+    gen = NativeKFXGenerator()
+    chapters = [{"title": "Ch", "text": "plain body text"}]  # no blocks
+    gen.generate_full_book(title="T", author="A", chapters=chapters,
+                           output_path=str(tmp_path / "o.kfx"))
+    styles = [f for f in gen.fragments if str(f.ftype) == "$157"]
+    for f in styles:
+        if IS("$48") in f.value:
+            assert f.value[IS("$48")][IS("$306")] == IS("$314")  # default % unit
+        assert IS("$50") not in f.value  # margin-right never default
+```
+
+(Add `@pytest.mark.unit`.)
+
+- [ ] **Step 2: Run the full unit suite**
+
+Run: `<venv>/bin/pytest tests/unit -q`
+Expected: PASS (all).
+
+- [ ] **Step 3: Lint repo-wide + commit**
+
+```bash
+<venv>/bin/ruff check . && <venv>/bin/ruff format --check .
+git add -A
+git commit -m "test(css): default-margin stability guard (#9)"
+```
+
+- [ ] **Step 4: Real-Stylizer smoke (anti-silent-no-op; manual, controller-run)**
+
+The unit tests use a fake resolver; the `EpubAsOeb` shim can't drive the real Stylizer. Build an EPUB with a `<blockquote>` styled `margin-left: 2em` (CSS file or inline `style=`), convert it through the real Calibre Stylizer (branch code via the input-plugin → `create_oebbook` → `convert_oeb_to_kfx` harness, no install), decode the `.kfx`, and assert a `$157` carries `$48` with a non-`$314` unit (the blockquote's em margin). If absent, the resolver didn't supply margins — investigate before proceeding.
+
+- [ ] **Step 5: Gutenberg corpus + device gates (manual, release-time)**
+
+Run the 90-book corpus crash/no-regression check (content gate; margins don't change text retention). On a physical Kindle, confirm blockquotes/indented blocks render with the expected left (and right) offset. Record on #9.
+
+---
+
+## Self-review
+
+- **Spec coverage:** margin-left `$48` override (Tasks 1,2,4) ✓; margin-right `$50` emit (Tasks 1,2,4) ✓; Stylizer supplies margins (Task 3) ✓; negatives rejected (reuses `parse_css_length`, tested Task 1) ✓; byte-stable defaults (Tasks 2,5) ✓; real-Stylizer smoke + corpus + device (Task 5) ✓. Vertical margins/padding explicitly out of scope (spec) — not a gap.
+- **Placeholders:** none — every code/test step has concrete code.
+- **Type consistency:** `block_style` keys `margin_left`/`margin_right` are `(mag, unit_sym)` tuples or `None` in Tasks 1,3,4; `build_fragment_157(margin_left=, margin_right=)` signature matches across Tasks 2,4; `$48`/`$50` symbols and unit symbols consistent throughout.

--- a/docs/superpowers/specs/2026-06-29-block-margins-design.md
+++ b/docs/superpowers/specs/2026-06-29-block-margins-design.md
@@ -1,0 +1,145 @@
+# Design: Block horizontal margins — margin-left + margin-right (Plan C of #9)
+
+Date: 2026-06-29
+Issue: #9 (Carry inline emphasis and more CSS typography through to KFX styles)
+Status: Approved (brainstorming) — pending spec review
+Predecessors: Plan A (inline emphasis, PR #19) and Plan B (text-align + text-indent, PR #22), both shipped and device-verified.
+
+## Problem
+
+Block-level horizontal indentation from the source EPUB — `margin-left` /
+`margin-right` on blockquotes, pull-quotes, and indented verse — is dropped.
+These render flush with body text, losing the visual offset the author intended.
+
+## Scope
+
+In:
+- per-element **margin-left** (`$48`)
+- per-element **margin-right** (`$50`)
+
+Out (deferred, separate effort):
+- **Vertical margins** (`margin-top` `$47`, `margin-bottom` `$49`). margin-top
+  collides with kfxgen's forced paragraph-spacing default (`$47` = 1lh), and the
+  existing spacing model + Plan B's indent-suppression already cover vertical
+  spacing for the common case. Low marginal value, higher reconciliation risk.
+- **Padding** (a separate symbol set, `$52`–`$58`).
+
+## Symbol reference (authoritative — jhowell kfxlib `yj_to_epub_properties.py`)
+
+| CSS property | KFX symbol |
+|---|---|
+| margin-left | `$48` |
+| margin-right | `$50` |
+| margin-top | `$47` (out of scope) |
+| margin-bottom | `$49` (out of scope) |
+| margin (shorthand) | `$46` |
+
+Note on the current code: `build_fragment_157` emits `$48` = 0.5% on every
+non-heading style, with a comment calling it "margin-bottom: 0.5%". Per the
+authoritative catalog `$48` is **margin-left**, so kfxgen has been emitting a
+harmless ~0.5% left margin (the comment is wrong; the render is fine). `$47`
+(commented "padding-top: 1lh") is likewise actually **margin-top** and is what
+produces paragraph spacing. This design uses the authoritative meanings and does
+NOT change the existing defaults — it only overrides `$48` per-block when the
+source specifies a margin-left, and adds `$50` per-block when the source
+specifies a margin-right. Fixing the stale comments is a trivial side cleanup.
+
+## Architecture
+
+### Data model
+
+`block_style` (from Plan B) gains two keys:
+
+```python
+"block_style": {
+    "align": str | None,            # Plan B
+    "indent": (mag, unit_sym) | None,   # Plan B
+    "margin_left": (mag, unit_sym) | None,   # NEW
+    "margin_right": (mag, unit_sym) | None,  # NEW
+}
+```
+
+### Pure helper (`inline_style.compute_block_style`)
+
+Also read `margin-left` and `margin-right` from the computed-CSS dict via the
+existing `parse_css_length`. `parse_css_length` already rejects negative and
+zero magnitudes and unsupported units (returns `None`), so negative margins
+safely become no-overrides — no left-edge clipping (the Plan B negative-indent
+lesson). Returns the two new keys (values may be `None`).
+
+### Generation (`native_generator.build_fragment_157`)
+
+Add `margin_left=None` and `margin_right=None`:
+- **margin-left (`$48`)**: when `margin_left` is a `(mag, unit_sym)` tuple, emit
+  `$48` with that magnitude+unit (overriding the 0.5% default for this style);
+  when `None`, keep the existing `$48` = 0.5% default.
+- **margin-right (`$50`)**: when `margin_right` is set, emit `$50` with that
+  magnitude+unit; when `None`, emit nothing (currently `$50` is never emitted).
+- Both `None` → output byte-identical to today.
+
+### Threading (`native_generator._build_chapter_content`)
+
+The plain-text entry branch already builds `attrs` from `block_style` (Plan B).
+Extend it to add `margin_left` / `margin_right` to `attrs` only when present,
+then `_allocate_style("", **attrs)`. Distinct margin combinations dedupe via the
+existing cache. When no margins apply, `attrs` is unchanged from Plan B → same
+cached style → byte-stable.
+
+## Behaviors
+
+- Honor source `margin-left` / `margin-right` on block elements (blockquotes,
+  indented blocks). The source value **replaces** (not adds to) the 0.5% `$48`
+  default for that block.
+- Negative or zero margins → no override (safe).
+- Independent of text-indent (`$36`) and alignment (`$34`) — all can co-apply.
+
+## Byte-stability
+
+Blocks with no source horizontal margins produce identical output: `$48` stays
+0.5%, no `$50`. Only blocks that specify margin-left/right change. Guarded by the
+default-stability test (extended to assert `$48` = 0.5% / `$314` and `$50`
+absent on an unstyled book).
+
+## Error handling
+
+- Stylizer unavailable / per-element failure → `block_style` `None` (Plan A/B
+  fallback), no margins applied.
+- Unmappable / negative / zero margin values → omitted (no override).
+
+## Testing
+
+- **Unit (no Calibre):** `compute_block_style` margin-left/right (valid, zero,
+  negative, unmappable); `build_fragment_157` with `margin_left` (overrides
+  `$48`) and `margin_right` (emits `$50`), and byte-stable defaults when both
+  `None`.
+- **Extraction:** `extract_blocks_from_html` with a fake `style_resolver`
+  returning `margin-left` for a `<blockquote>` → `block_style.margin_left` set.
+- **Integration:** a chapter whose block has `margin_left` → generated KFX has a
+  `$157` with `$48` = the source value (not 0.5%).
+- **Real-Stylizer smoke (anti-silent-no-op):** convert an EPUB containing a
+  `<blockquote>` with a CSS `margin-left` through the real Calibre Stylizer
+  (branch code, no install) and assert a `$157` carries the non-default `$48`.
+  The fake-resolver unit tests cannot exercise the real Stylizer.
+- **Gutenberg corpus:** crash/no-regression run across the 90-book corpus
+  (content gate; margins don't change text retention).
+- **Device (release gate):** blockquotes/indented blocks render with the
+  expected left (and right) offset on a physical Kindle.
+
+## Risks
+
+1. **Stylizer margin value form** — same as Plan B's indent; `parse_css_length`
+   maps whatever unit appears (em/%/pt/px/mm/rem) and skips the rest. Verified
+   in the real-Stylizer smoke.
+2. **`$48` override vs the 0.5% default** — the override replaces the default per
+   block; non-margin blocks keep 0.5% (byte-stable). The mislabeled-comment
+   situation is documented; defaults are not changed.
+3. **Negative margins** — already rejected by `parse_css_length` (no clipping).
+
+## Boundary with related issues
+
+- Builds directly on Plan B's `block_style` / `_allocate_style` machinery.
+- Vertical margins + the stale `$47`/`$48` comment cleanup: this spec corrects
+  the comments and uses authoritative symbols, but vertical margins remain
+  deferred.
+- Completes the "more CSS typography" portion of #9 (emphasis + align + indent +
+  horizontal margins); #9 can close after this ships.

--- a/plugin/kfxgen/converter.py
+++ b/plugin/kfxgen/converter.py
@@ -41,6 +41,8 @@ def _build_style_resolver(oeb_book, item, log):
                 return {
                     "text-align": st.get("text-align"),
                     "text-indent": st.get("text-indent"),
+                    "margin-left": st.get("margin-left"),
+                    "margin-right": st.get("margin-right"),
                 }
             except Exception:
                 return None

--- a/plugin/kfxgen/inline_style.py
+++ b/plugin/kfxgen/inline_style.py
@@ -109,12 +109,20 @@ def compute_block_style(css):
 
     `css` is a mapping that supports .get(prop) returning CSS strings (e.g. a
     Calibre Stylizer Style, or a plain dict in tests). Returns
-    {"align": <keyword or None>, "indent": <(mag, unit_sym) or None>}.
-    The align keyword is mapped to a symbol later, in build_fragment_157.
+    {"align": <keyword or None>, "indent"/"margin_left"/"margin_right":
+    <(mag, unit_sym) or None>}. The align keyword is mapped to a symbol later,
+    in build_fragment_157.
     """
     align = None
     raw_align = (css.get("text-align") or "").strip().lower()
     if raw_align in ALIGN_MAP:
         align = raw_align
     indent = parse_css_length(css.get("text-indent") or "")
-    return {"align": align, "indent": indent}
+    margin_left = parse_css_length(css.get("margin-left") or "")
+    margin_right = parse_css_length(css.get("margin-right") or "")
+    return {
+        "align": align,
+        "indent": indent,
+        "margin_left": margin_left,
+        "margin_right": margin_right,
+    }

--- a/plugin/kfxgen/native_generator.py
+++ b/plugin/kfxgen/native_generator.py
@@ -2632,6 +2632,10 @@ class NativeKFXGenerator:
                         attrs["align"] = bs["align"]
                     if bs.get("indent"):
                         attrs["text_indent"] = bs["indent"]
+                    if bs.get("margin_left"):
+                        attrs["margin_left"] = bs["margin_left"]
+                    if bs.get("margin_right"):
+                        attrs["margin_right"] = bs["margin_right"]
                     entry_styles.append(_allocate_style("", **attrs))
                     entry_link_targets.append(None)
                     entry_link_styles.append(None)

--- a/plugin/kfxgen/native_generator.py
+++ b/plugin/kfxgen/native_generator.py
@@ -932,6 +932,8 @@ class NativeKFXGenerator:
         italic=False,
         align=None,
         text_indent=None,
+        margin_left=None,
+        margin_right=None,
     ):
         """
         Builds Fragment $157 (Style Definition).
@@ -954,6 +956,10 @@ class NativeKFXGenerator:
             text_indent: If a tuple (magnitude_str, unit_symbol), set text-indent ($36)
                         and suppress padding-top. Default None uses 0% indent and
                         normal padding behavior.
+            margin_left: If a tuple (magnitude_str, unit_symbol), override the default
+                        margin-left ($48). Default None uses 0.5% ($314).
+            margin_right: If a tuple (magnitude_str, unit_symbol), emit margin-right ($50).
+                         Default None omits $50.
 
         Returns:
             YJFragment with type $157
@@ -982,11 +988,22 @@ class NativeKFXGenerator:
                 IS("$307"), IonDecimal("0"), IS("$306"), IS("$314")
             )
 
+        # $48 = margin-left; default 0.5%, overridden per element.
+        if margin_left is not None:
+            margin_left_struct = IonStruct(
+                IS("$307"),
+                IonDecimal(margin_left[0]),
+                IS("$306"),
+                IS(margin_left[1]),
+            )
+        else:
+            margin_left_struct = IonStruct(
+                IS("$307"), IonDecimal("0.5"), IS("$306"), IS("$314")
+            )
+
         value = IonStruct(
             IS("$48"),
-            IonStruct(
-                IS("$307"), IonDecimal("0.5"), IS("$306"), IS("$314")
-            ),  # margin-bottom: 0.5%
+            margin_left_struct,
             IS("$34"),
             text_align,  # text-align: justify ($320=center, $321=justify, $59=left, $61=right)
             IS("$36"),
@@ -1028,6 +1045,12 @@ class NativeKFXGenerator:
         if margin_top is not None:
             value[IS("$46")] = IonStruct(
                 IS("$307"), IonDecimal(str(margin_top)), IS("$306"), IS("$310")
+            )
+
+        # $50 = margin-right; emitted only when the source specifies it.
+        if margin_right is not None:
+            value[IS("$50")] = IonStruct(
+                IS("$307"), IonDecimal(margin_right[0]), IS("$306"), IS(margin_right[1])
             )
 
         return YJFragment(fid=IS(entity_name), ftype=IS("$157"), value=value)

--- a/tests/unit/test_converter.py
+++ b/tests/unit/test_converter.py
@@ -579,8 +579,18 @@ def test_blocks_block_style_from_resolver():
         return {}
 
     blocks = _conv.extract_blocks_from_html(doc, style_resolver=resolver)
-    assert blocks[0]["block_style"] == {"align": "center", "indent": ("2", "$308")}
-    assert blocks[1]["block_style"] == {"align": None, "indent": None}
+    assert blocks[0]["block_style"] == {
+        "align": "center",
+        "indent": ("2", "$308"),
+        "margin_left": None,
+        "margin_right": None,
+    }
+    assert blocks[1]["block_style"] == {
+        "align": None,
+        "indent": None,
+        "margin_left": None,
+        "margin_right": None,
+    }
 
 
 @pytest.mark.unit
@@ -588,6 +598,23 @@ def test_blocks_block_style_none_without_resolver():
     doc = _doc("<p>x</p>")
     blocks = _conv.extract_blocks_from_html(doc)
     assert blocks[0]["block_style"] is None
+
+
+@pytest.mark.unit
+def test_blocks_block_style_margins_from_resolver():
+    doc = _doc("<blockquote>quoted</blockquote><p>plain</p>")
+
+    def resolver(elem):
+        txt = "".join(elem.itertext())
+        if "quoted" in txt:
+            return {"margin-left": "2em", "margin-right": "1em"}
+        return {}
+
+    blocks = _conv.extract_blocks_from_html(doc, style_resolver=resolver)
+    assert blocks[0]["block_style"]["margin_left"] == ("2", "$308")
+    assert blocks[0]["block_style"]["margin_right"] == ("1", "$308")
+    assert blocks[1]["block_style"]["margin_left"] is None
+    assert blocks[1]["block_style"]["margin_right"] is None
 
 
 # ── Task 4: Stylizer-backed style_resolver ───────────────────────────────────

--- a/tests/unit/test_inline_style.py
+++ b/tests/unit/test_inline_style.py
@@ -114,3 +114,19 @@ def test_compute_block_style_indent():
     )
     assert ist.compute_block_style({"text-indent": "0"})["indent"] is None
     assert ist.compute_block_style({})["indent"] is None
+
+
+@pytest.mark.unit
+def test_compute_block_style_margins():
+    bs = ist.compute_block_style({"margin-left": "2em", "margin-right": "1em"})
+    assert bs["margin_left"] == ("2", "$308")
+    assert bs["margin_right"] == ("1", "$308")
+
+
+@pytest.mark.unit
+def test_compute_block_style_margins_absent_and_negative():
+    bs = ist.compute_block_style({})
+    assert bs["margin_left"] is None and bs["margin_right"] is None
+    # negative margins are dropped (no clipping), like negative indent
+    bs2 = ist.compute_block_style({"margin-left": "-3em"})
+    assert bs2["margin_left"] is None

--- a/tests/unit/test_native_generator.py
+++ b/tests/unit/test_native_generator.py
@@ -1173,3 +1173,40 @@ def test_per_chapter_font_size_not_leaked_from_last_chapter(tmp_path):
         "expected a $157 with font_size=0.75rem for the first chapter; "
         "got none — leaked-loop-variable bug may still be present"
     )
+
+
+@pytest.mark.unit
+def test_block_margin_left_produces_overridden_48(tmp_path):
+    from kfxgen.kfxlib_minimal.ion import IS, IonDecimal
+
+    gen = NativeKFXGenerator()
+    chapters = [
+        {
+            "title": "Ch",
+            "text": "quoted line",
+            "blocks": [
+                {
+                    "text": "quoted line",
+                    "spans": [],
+                    "block_style": {
+                        "align": None,
+                        "indent": None,
+                        "margin_left": ("2", "$308"),
+                        "margin_right": None,
+                    },
+                }
+            ],
+        }
+    ]
+    gen.generate_full_book(
+        title="T", author="A", chapters=chapters, output_path=str(tmp_path / "o.kfx")
+    )
+    styles = [f for f in gen.fragments if str(f.ftype) == "$157"]
+    hit = [
+        f
+        for f in styles
+        if IS("$48") in f.value
+        and f.value[IS("$48")].get(IS("$307")) == IonDecimal("2")
+        and f.value[IS("$48")].get(IS("$306")) == IS("$308")
+    ]
+    assert hit, "expected a $157 with margin-left overridden to 2em"

--- a/tests/unit/test_native_generator.py
+++ b/tests/unit/test_native_generator.py
@@ -1210,3 +1210,22 @@ def test_block_margin_left_produces_overridden_48(tmp_path):
         and f.value[IS("$48")].get(IS("$306")) == IS("$308")
     ]
     assert hit, "expected a $157 with margin-left overridden to 2em"
+
+
+@pytest.mark.unit
+def test_no_block_style_keeps_default_margins(tmp_path):
+    from kfxgen.kfxlib_minimal.ion import IS
+
+    gen = NativeKFXGenerator()
+    chapters = [{"title": "Ch", "text": "plain body text"}]  # no blocks
+    gen.generate_full_book(
+        title="T",
+        author="A",
+        chapters=chapters,
+        output_path=str(tmp_path / "o.kfx"),
+    )
+    styles = [f for f in gen.fragments if str(f.ftype) == "$157"]
+    for f in styles:
+        if IS("$48") in f.value:
+            assert f.value[IS("$48")][IS("$306")] == IS("$314")  # default % unit
+        assert IS("$50") not in f.value  # margin-right never default

--- a/tests/unit/test_native_generator.py
+++ b/tests/unit/test_native_generator.py
@@ -309,6 +309,34 @@ class TestBuildFragment157:
         assert ind[IS("$307")] == IonDecimal("0")
         assert IS("$47") in frag.value  # padding-top present by default (non-heading)
 
+    def test_margin_left_overrides_48(self):
+        from kfxgen.kfxlib_minimal.ion import IS, IonDecimal
+
+        gen = NativeKFXGenerator()
+        frag = gen.build_fragment_157(entity_name="sml", margin_left=("2", "$308"))
+        ml = frag.value[IS("$48")]
+        assert ml[IS("$307")] == IonDecimal("2")
+        assert ml[IS("$306")] == IS("$308")
+
+    def test_margin_right_emits_50(self):
+        from kfxgen.kfxlib_minimal.ion import IS, IonDecimal
+
+        gen = NativeKFXGenerator()
+        frag = gen.build_fragment_157(entity_name="smr", margin_right=("1", "$308"))
+        mr = frag.value[IS("$50")]
+        assert mr[IS("$307")] == IonDecimal("1")
+        assert mr[IS("$306")] == IS("$308")
+
+    def test_margins_default_byte_stable(self):
+        from kfxgen.kfxlib_minimal.ion import IS, IonDecimal
+
+        gen = NativeKFXGenerator()
+        frag = gen.build_fragment_157(entity_name="smd")
+        ml = frag.value[IS("$48")]
+        assert ml[IS("$307")] == IonDecimal("0.5")
+        assert ml[IS("$306")] == IS("$314")
+        assert IS("$50") not in frag.value
+
 
 class TestStyleSharing:
     """Issue #5: $157 styles must be shared globally, not cloned per chapter.


### PR DESCRIPTION
Implements **Plan C of #9** — carry per-element `margin-left` and `margin-right` from the source EPUB into KFX block styles (blockquotes, indented blocks). Final piece of #9 (emphasis ✓ + align/indent ✓ + horizontal margins ✓). Vertical margins (top/bottom) and padding remain out of scope.

## Approach (extends Plan B's machinery)

- **`inline_style`**: `compute_block_style` reads `margin-left`/`margin-right` via the existing `parse_css_length` (which already rejects negative/zero/unsupported → no clipping).
- **`converter`**: `_build_style_resolver` returns the two margin props from the real Stylizer.
- **`build_fragment_157`**: `margin_left` overrides the default `$48`; `margin_right` emits `$50` (previously unused). Both `None` → byte-identical output.
- **`_build_chapter_content`**: threads margins through the existing `_allocate_style` cache under truthy guards (byte-stable for unstyled blocks).

## Verification

- 394 unit tests pass; `ruff check` + `ruff format --check` clean.
- **Final whole-branch review: ready to merge** — no Critical/Important; byte-stability is structural (cache key unchanged for unstyled books).
- **Real-Stylizer blockquote smoke**: actual Calibre Stylizer → non-default `$48` + `$50` through branch code (closes the silent-no-op risk the fake-resolver unit tests can't).
- **90-book Gutenberg corpus crash-check: 90/90, 0 failures** with the margin code active.
- **Device-verified** on a physical Kindle: a `<blockquote>` renders inset on both sides; normal paragraphs stay flush; no clipped text.

## Non-blocking follow-ups (noted)
- `margin_right` threading lacks a dedicated integration test (its `$50` emission is unit-tested; threading is symmetric to margin-left).
- Stale `$47` "padding-top" comment (really margin-top) — small cleanup, vertical margins out of scope.

Spec: `docs/superpowers/specs/2026-06-29-block-margins-design.md`
Plan: `docs/superpowers/plans/2026-06-29-block-margins.md`

Closes #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)