### PR TITLE
Dynamic section-position base — guaranteed content/section eid disjointness (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ overflow it. Normal books are byte-identical (no re-verification needed). The
 #23 scale gate now asserts disjointness directly; the xfail marker has been
 removed.
 
+Verified against the upstream `kfxlib` decoder: a 1,170-chapter book that
+previously produced 1,141 `duplicate eid` warnings from the range overlap now
+produces zero. Device-verified: that book (section eids relocated to ~20k)
+navigates correctly on a physical Kindle — late-chapter TOC taps land on target
+and the progress readout is sane.
+
 ## 5.3.22 — Within-file #anchor chapter splitting (#23)
 
 kfxgen can now split chapters at inline `#anchor` targets inside a single

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 5.3.23 — Dynamic section-position base (#30)
+
+Content and section eid ranges are now disjoint by construction at any chapter
+count. `SECTION_POS_BASE` is a floor: sections stay at 10 000 for normal books
+and relocate just above the content range only for books that would otherwise
+overflow it. Normal books are byte-identical (no re-verification needed). The
+#23 scale gate now asserts disjointness directly; the xfail marker has been
+removed.
+
 ## 5.3.22 — Within-file #anchor chapter splitting (#23)
 
 kfxgen can now split chapters at inline `#anchor` targets inside a single

--- a/docs/superpowers/plans/2026-06-30-dynamic-section-base.md
+++ b/docs/superpowers/plans/2026-06-30-dynamic-section-base.md
@@ -1,0 +1,287 @@
+# Dynamic Section-Position Base Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the `$260` section-position base dynamic so content and section eid ranges are disjoint by construction at any chapter count, while leaving normal books byte-identical (#30).
+
+**Architecture:** Content positions are unchanged. After content assignment, compute `content_max` and set the section base to `max(SECTION_POS_BASE, content_max + SECTION_POS_STEP)` — so sections keep base `10000` when content fits under it, and relocate just above the content range only when content would otherwise overflow. The guarantee is asserted as content/section eid-set disjointness, replacing the fixed-threshold `xfail` gate from #23.
+
+**Tech Stack:** Python 3.13, pytest. All production changes in `plugin/kfxgen/native_generator.py`; tests in `tests/unit/test_converter.py`.
+
+## Global Constraints
+
+- Run tests with `.venv/bin/python -m pytest` (the venv has the deps).
+- Lint gate: `.venv/bin/python -m ruff check` AND `ruff format --check`, ruff pinned `0.15.1` (`.venv/bin/python -m ruff`; `.venv/bin/pip install ruff==0.15.1 -q` if the venv differs).
+- Content positions and their assignment loop are UNCHANGED. `CONTENT_POS_BASE=1000`, `CONTENT_POS_STEP=2`, `SECTION_POS_BASE=10000`, `SECTION_POS_STEP=2` stay as the defaults/floor.
+- Content eids are always even (base 1000 even, step 2), so `content_max + SECTION_POS_STEP` stays even-aligned — no explicit rounding needed.
+- Normal books (content_max < SECTION_POS_BASE) MUST produce byte-identical output; golden fixtures are NOT regenerated.
+- Branch: `feat/30-dynamic-section-base`. Commit after every task.
+
+---
+
+### Task 1: Dynamic section base + disjointness tests
+
+**Files:**
+- Modify: `plugin/kfxgen/native_generator.py` (add `_section_base` classmethod; use it in the `section_positions` assignment ~line 2443; update the constants comment ~2107-2120)
+- Test: `tests/unit/test_converter.py`
+
+**Interfaces:**
+- Produces: `NativeKFXGenerator._section_base(content_max: int) -> int` — the section base for a book whose largest content eid is `content_max`. Returns `SECTION_POS_BASE` when `content_max < SECTION_POS_BASE`, else `content_max + SECTION_POS_STEP`.
+
+- [ ] **Step 1: Write the failing unit tests for `_section_base`**
+
+Add to `tests/unit/test_converter.py`. `NativeKFXGenerator` is only imported
+locally inside other test methods in this file, so import it inside these tests
+too (matching that pattern):
+
+```python
+class TestSectionBase:
+    def test_normal_book_keeps_default_base(self):
+        from kfxgen.native_generator import NativeKFXGenerator
+
+        # content well under the floor -> sections stay at SECTION_POS_BASE
+        assert NativeKFXGenerator._section_base(3398) == 10000
+        assert NativeKFXGenerator._section_base(9998) == 10000
+
+    def test_overflow_relocates_above_content(self):
+        from kfxgen.native_generator import NativeKFXGenerator
+
+        # content at/above the floor -> section base moves just above content_max
+        assert NativeKFXGenerator._section_base(10000) == 10002
+        assert NativeKFXGenerator._section_base(17798) == 17800
+
+    def test_result_is_even_aligned(self):
+        from kfxgen.native_generator import NativeKFXGenerator
+
+        # content eids are always even; the relocated base stays even
+        for cm in (10000, 10002, 12344, 17798):
+            assert NativeKFXGenerator._section_base(cm) % 2 == 0
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_converter.py::TestSectionBase -v`
+Expected: FAIL — `AttributeError: type object 'NativeKFXGenerator' has no attribute '_section_base'`.
+
+- [ ] **Step 3: Implement `_section_base` and use it**
+
+In `plugin/kfxgen/native_generator.py`, add the classmethod near the position constants (after line 2125, `SECTION_POS_STEP = 2`):
+
+```python
+    @classmethod
+    def _section_base(cls, content_max):
+        """Base position id for $260 sections.
+
+        Sections start strictly above the content range so content and
+        section eids never collide (#30). For normal books (content stays
+        under SECTION_POS_BASE) this is the floor SECTION_POS_BASE, keeping
+        output byte-identical; only books whose content would overflow the
+        floor relocate their sections just above content_max. Content eids
+        are always even, so content_max + SECTION_POS_STEP stays even-aligned.
+        """
+        return max(cls.SECTION_POS_BASE, content_max + cls.SECTION_POS_STEP)
+```
+
+Then change the `section_positions` assignment. Current code (~2440-2446):
+
+```python
+        # Section position IDs (for $260) — separate range, may arithmetically
+        # collide with chunk positions for busy books (v5.2.0 had ~71 such
+        # collisions on the test corpus and worked correctly).
+        section_positions = [
+            self.SECTION_POS_BASE + i * self.SECTION_POS_STEP
+            for i in range(len(chapters))
+        ]
+```
+
+Replace with (note `content_pos_id` is the next-unused value after the content
+loop, so the last assigned content eid is `content_pos_id - CONTENT_POS_STEP`):
+
+```python
+        # Section position IDs (for $260). The base is dynamic (#30): sections
+        # start strictly above the content range so content and section eids
+        # are disjoint at any chapter count. Normal books keep SECTION_POS_BASE
+        # (byte-identical); only overflow books relocate.
+        content_max = content_pos_id - self.CONTENT_POS_STEP
+        section_base = self._section_base(content_max)
+        section_positions = [
+            section_base + i * self.SECTION_POS_STEP
+            for i in range(len(chapters))
+        ]
+```
+
+- [ ] **Step 4: Update the stale constants comment**
+
+In the comment block above the constants (~lines 2108-2120), the text says the
+`10000+` section range is fixed and "Don't widen." Replace the bullet that reads:
+
+```python
+    #   - Despite (a), the values themselves matter. Pushing
+    #     SECTION_POS_BASE up to 100000 broke Kindle's progress display
+    #     ("at start of book" showed 100% complete). The 5-digit range
+    #     v5.2.0 used (≤ 16000-ish for content, 10000+ for sections) is
+    #     the known-good envelope. Don't widen.
+```
+
+with:
+
+```python
+    #   - Despite (a), the values themselves matter. Pushing
+    #     SECTION_POS_BASE up to 100000 broke Kindle's progress display
+    #     ("at start of book" showed 100% complete). Keep section eids in
+    #     the low 5-digit range Kindle has been observed to handle.
+    #   - The section base is dynamic (#30): SECTION_POS_BASE is the floor,
+    #     but for books whose content overflows it the sections relocate to
+    #     just above content_max (via _section_base) so content and section
+    #     eids stay disjoint. Normal books are unaffected (stay at 10000).
+```
+
+- [ ] **Step 5: Run the `_section_base` tests to verify they pass**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_converter.py::TestSectionBase -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Rewrite the #23 scale gate to assert disjointness (remove xfail)**
+
+Replace the whole `TestHighChapterCountScale` class (currently at
+`tests/unit/test_converter.py:963`, the `@pytest.mark.xfail`-marked
+`test_1200_chapter_book_converts_and_stays_in_envelope`) with:
+
+```python
+class TestHighChapterCountScale:
+    """A large book (1200 chapters × several paragraphs) must keep content and
+    section eid ranges disjoint by construction (#30) — no reliance on the
+    old fixed 10000 boundary, which this book's content overflows."""
+
+    def test_1200_chapter_book_has_disjoint_eid_ranges(self, tmp_path):
+        from kfxgen.native_generator import NativeKFXGenerator
+        from kfxgen.kfxlib_minimal.ion import IS
+        from tests._kfx_introspect import by_type, val, load_fragments
+
+        chapters = [
+            {
+                "title": f"Chapter {i}",
+                "text": (
+                    f"Chapter {i}\n\n"
+                    f"First sentence of chapter {i}.\n\n"
+                    f"Second sentence of chapter {i}.\n\n"
+                    f"Third sentence of chapter {i}.\n\n"
+                    f"Fourth sentence of chapter {i}.\n\n"
+                    f"Fifth sentence of chapter {i}."
+                ),
+            }
+            for i in range(1200)
+        ]
+        out = tmp_path / "scale.kfx"
+        NativeKFXGenerator().generate_full_book(
+            title="Scale", author="T", chapters=chapters, output_path=str(out)
+        )
+        frags = load_fragments(out)
+
+        assert len(by_type(frags, "$260")) == 1200
+
+        content_eids = set()
+        for f in by_type(frags, "$259"):
+            v = val(f)
+            for e in v.get(IS("$146")) or v.get(IS("$181")) or []:
+                if hasattr(e, "get") and e.get(IS("$155")) is not None:
+                    content_eids.add(int(e.get(IS("$155"))))
+
+        section_eids = set()
+        for f in by_type(frags, "$260"):
+            v = val(f)
+            for e in v.get(IS("$141")) or []:
+                if hasattr(e, "get") and e.get(IS("$155")) is not None:
+                    section_eids.add(int(e.get(IS("$155"))))
+
+        # Content pushes past the old 10000 floor at this scale...
+        assert max(content_eids) >= NativeKFXGenerator.SECTION_POS_BASE
+        # ...but content and section eid sets are still disjoint by construction.
+        assert content_eids.isdisjoint(section_eids), (
+            f"content/section eid overlap: "
+            f"{sorted(content_eids & section_eids)[:10]}"
+        )
+
+        # #23 invariant still holds: every section eid is present in $265.
+        pos_265 = set()
+        for f in by_type(frags, "$265"):
+            v = val(f)
+            entries = v if isinstance(v, list) else v.get(IS("$181")) or []
+            for e in entries:
+                if hasattr(e, "get") and e.get(IS("$185")) is not None:
+                    pos_265.add(int(e.get(IS("$185"))))
+        missing = section_eids - pos_265
+        assert not missing, f"section eids absent from $265: {sorted(missing)[:10]}"
+```
+
+- [ ] **Step 7: Run the scale test + full regression**
+
+Run: `.venv/bin/python -m pytest tests/unit/test_converter.py tests/unit/test_position_map.py tests/integration/test_golden_corpus.py -q`
+Expected: PASS. The scale test now passes (asserting disjointness, no xfail); the position-map tests (small fixtures) and golden bytes are unchanged.
+
+- [ ] **Step 8: Lint + commit**
+
+```bash
+.venv/bin/python -m ruff check plugin/kfxgen/native_generator.py tests/unit/test_converter.py
+.venv/bin/python -m ruff format plugin/kfxgen/native_generator.py tests/unit/test_converter.py
+git add plugin/kfxgen/native_generator.py tests/unit/test_converter.py
+git commit -m "feat: dynamic $260 section base for guaranteed eid disjointness (#30)"
+```
+
+---
+
+### Task 2: Release prep + device gate
+
+**Files:**
+- Modify: `plugin/kfxgen/__init__.py` (version), `CHANGELOG.md`
+
+- [ ] **Step 1: Full suite**
+
+Run: `.venv/bin/python -m pytest -q`
+Expected: all pass (12 tier-2 skip without the vendored zip is expected). The #30 scale test now passes and there is no longer an xfail for it. Fix nothing silently; if anything regresses, STOP and report.
+
+- [ ] **Step 2: Golden corpus unchanged**
+
+Run: `.venv/bin/python -m pytest tests/integration/test_golden_corpus.py -q -m "tier3 or tier3_strict"`
+Expected: PASS with NO regeneration — golden inputs are normal-sized (content well under 10000), so section bases stay at 10000 and bytes are identical. If tier3_strict fails, STOP and report (it would mean a normal book changed, which violates the design's byte-identical guarantee — do NOT regenerate to paper over it).
+
+- [ ] **Step 3: Version + CHANGELOG**
+
+Bump `version` in `plugin/kfxgen/__init__.py` 5.3.22 → 5.3.23. Prepend a
+`## 5.3.23 — Dynamic section-position base (#30)` entry to `CHANGELOG.md`
+summarizing: content and section eid ranges are now disjoint by construction at
+any chapter count; `SECTION_POS_BASE` is a floor and sections relocate just
+above the content range only for books that would otherwise overflow; normal
+books are byte-identical (no re-verification); the #23 scale gate now asserts
+disjointness (xfail removed). Match the style of the existing top entries.
+
+- [ ] **Step 4: Lint gate (pinned ruff)**
+
+```bash
+.venv/bin/python -m ruff check plugin/ tests/
+.venv/bin/python -m ruff format --check plugin/ tests/
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "chore: bump 5.3.23, CHANGELOG for #30 dynamic section base"
+```
+
+- [ ] **Step 6: Device verification gate (manual — STOP for the user)**
+
+Build + install the branch plugin (`./build_plugin.sh --install`) and convert a
+huge book (Complete Works of Shakespeare) via `ebook-convert` to a `.kfx`. Have
+the user sideload it to a physical Kindle and confirm TOC navigation still works
+now that the section eids for that book are relocated to ~20k. Normal books need
+no re-verification (byte-identical). Do NOT mark #30 done until the user confirms
+on-device.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** dynamic base + floor → Task 1 Step 3 (`_section_base` + assignment); disjointness-by-construction → Task 1 Steps 1/6; stated-invariant test change → Task 1 Step 6; byte-identical normal books → Task 2 Step 2 (golden unchanged); boundary/overflow → Task 1 Steps 1 (`10000`/`17798` cases) + 6; device gate → Task 2 Step 6; release → Task 2.
+- **Placeholders:** none — every step has concrete code/commands.
+- **Type consistency:** `_section_base(content_max: int) -> int` defined in Task 1 Step 3, exercised in Task 1 Steps 1 and 6; constant names (`SECTION_POS_BASE`, `SECTION_POS_STEP`, `CONTENT_POS_STEP`) match `native_generator.py`.

--- a/docs/superpowers/specs/2026-06-30-dynamic-section-base-design.md
+++ b/docs/superpowers/specs/2026-06-30-dynamic-section-base-design.md
@@ -1,0 +1,113 @@
+# Dynamic section-position base — guaranteed content/section disjointness (#30)
+
+**Status:** Approved design — ready for implementation planning
+**Issue:** #30 · **Related:** #23 (introduced the high-chapter scale that exposed this; left an `xfail` gate pointing here), #20 (position-map conformance)
+**Branch:** `feat/30-dynamic-section-base`
+
+## Problem
+
+kfxgen assigns two fixed position-id ranges in `native_generator.py`:
+
+- content positions (`$259` outer + chunk children) start at `CONTENT_POS_BASE = 1000`, step `CONTENT_POS_STEP = 2`;
+- section positions (`$260` `$155`) start at `SECTION_POS_BASE = 10000`, step `SECTION_POS_STEP = 2`.
+
+Content grows with both chapter and chunk count:
+`content_max = CONTENT_POS_BASE + CONTENT_POS_STEP × (num_chapters + num_chunks)`.
+For a realistic large book (≈1,200 chapters × several paragraphs each) `content_max`
+reaches ≈17,798, climbing through and past the section range (10,000–≈12,398). Where
+an even content value equals an even section value, jhowell's reader logs
+`duplicate eid …`. #23's scale gate (`TestHighChapterCountScale`) is `xfail(strict=True)`
+against this issue.
+
+Device testing (#23) showed the overlap is tolerated in practice: a 1,170-chapter book
+renders and navigates on a physical Kindle. So this is correctness hardening — remove the
+overlap by construction — not a device-breaking bug fix.
+
+## Goal (Option 1: provable no-overlap, low-risk-first)
+
+Guarantee content and section eid ranges are **disjoint at any chapter count**, while
+keeping **normal books byte-identical** (no re-verification for the common case). Only
+books that would otherwise overflow change, and only in their section-eid values.
+
+Explicitly out of scope: a single shared eid namespace (the jhowell-reference style) —
+that would change eid values for every book and require full device re-verification.
+Also out of scope: reducing `CONTENT_POS_STEP` (would change every content eid and only
+move the overflow cliff rather than remove it).
+
+## Design
+
+### Mechanism (`native_generator.py`)
+
+1. Content-position assignment is unchanged. Track the largest content eid emitted as
+   `content_max` (the final `content_pos_id` value after the assignment loop, minus one
+   step, i.e. the last id actually assigned).
+2. Compute the section base dynamically rather than using the constant directly:
+   ```
+   section_base = max(SECTION_POS_BASE,
+                      _round_up_to_step(content_max + SECTION_POS_STEP))
+   ```
+   where `_round_up_to_step` rounds up so the section base stays aligned to
+   `SECTION_POS_STEP` (keeps section eids even, matching today).
+   - Normal book (`content_max < SECTION_POS_BASE`): `section_base = SECTION_POS_BASE`
+     (10,000) → identical output.
+   - Overflow book: sections relocate to just above the content range, with **minimal
+     padding** (one step), keeping section eids as low as possible — the code's history
+     warns that very high section bases (100,000) broke Kindle's progress display, so the
+     lower the relocated base, the safer.
+3. Build `section_positions` from `section_base` (contiguous, step `SECTION_POS_STEP`, as
+   today). By construction every section eid `> content_max ≥` every content eid, so the
+   two sets are disjoint.
+
+`SECTION_POS_BASE` remains the floor/default. `CONTENT_POS_BASE`, both steps, and the
+content-assignment loop are unchanged.
+
+### The invariant, stated correctly
+
+The guarantee that matters is "content eids and section eids are disjoint sets," not
+"content < a fixed 10,000." The fixed constant was only ever a proxy. Tests assert
+disjointness directly.
+
+## Ripple / affected code
+
+- Existing position-map tests run on small fixtures (content well under 10,000), so they
+  stay byte-identical and green with no change.
+- `TestHighChapterCountScale` (the `xfail` gate) is rewritten to assert content∩section
+  eid sets are empty and every section eid appears in `$265` (the #23 rule), then the
+  `xfail` marker is removed.
+- No production code outside `native_generator.py` classifies eids by comparing to
+  `SECTION_POS_BASE` in a way that breaks for overflow books (the classifier lives in
+  tests and introspection helpers, which operate on small fixtures). If a broader use is
+  found during implementation, switch it to set-membership (is-this-a-$260-eid) rather
+  than a numeric threshold.
+
+## Edge cases
+
+- Empty / single-chapter / tiny books: `content_max` small → `section_base` stays
+  `SECTION_POS_BASE` → unchanged.
+- Alignment: `_round_up_to_step` keeps the relocated base aligned to `SECTION_POS_STEP`
+  so section eids remain even (consistent with current output).
+- A book whose `content_max` is just below `SECTION_POS_BASE` keeps sections at 10,000
+  (no overlap, no relocation).
+
+## Testing
+
+- **Unit (generator):** a large synthetic book (≈1,200 chapters × multi-paragraph) →
+  assert content and section eid sets are disjoint, section eids ⊆ `$265`, and the book
+  converts without error. Replaces the `xfail`.
+- **Unit (boundary):** a book engineered so `content_max` lands just above
+  `SECTION_POS_BASE` → assert `section_base` relocated above `content_max` and ranges are
+  disjoint.
+- **Regression:** the existing golden corpus and position-map suites stay green (normal
+  fixtures unchanged); golden bytes are NOT regenerated.
+- **Device (manual gate):** one sideload of a huge book (Complete Works of Shakespeare)
+  to confirm the relocated ~20k section eids still navigate on a physical Kindle — the
+  same check already run for #23.
+
+## Success criteria
+
+- For any chapter/chunk count, content and section eid ranges are disjoint (no
+  `duplicate eid` from range collision).
+- Normal books produce byte-identical output (golden bytes unchanged, no device
+  re-verification).
+- The #23 scale gate passes (asserting disjointness) with the `xfail` removed.
+- A huge book still navigates on-device.

--- a/plugin/kfxgen/__init__.py
+++ b/plugin/kfxgen/__init__.py
@@ -12,7 +12,7 @@ __copyright__ = "2025-2026, Justin Loutsch <justin.loutsch@gmail.com>"
 
 #: Version tuple. Bump this for every release; the plugin wrapper and
 #: converter log message read from here.
-version = (5, 3, 22)
+version = (5, 3, 23)
 __version__ = ".".join(str(x) for x in version)
 
 __all__ = [

--- a/plugin/kfxgen/native_generator.py
+++ b/plugin/kfxgen/native_generator.py
@@ -2113,11 +2113,12 @@ class NativeKFXGenerator:
     #     but for books whose content overflows it the sections relocate to
     #     just above content_max (via _section_base) so content and section
     #     eids stay disjoint. Normal books are unaffected (stay at 10000).
-    #     Caveat: a huge book (~1200+ chapters) pushes relocated section eids
-    #     into the ~20k range — believed safe (well under the 100000 that
-    #     broke progress, and content itself already renders near ~18k) but
-    #     NOT yet device-observed at that height. Pending the #30 device gate;
-    #     don't treat ~20k as confirmed-good.
+    #     A huge book (~1200+ chapters) pushes relocated section eids into the
+    #     ~20k range. Device-verified (#30): a 1170-chapter book (Complete
+    #     Works of Shakespeare, section eids to ~20k) navigates correctly on a
+    #     physical Kindle — late-chapter TOC taps land right and the progress
+    #     readout is sane (88% at a late play). Still well under the 100000
+    #     that broke progress; keep section eids in the low 5-digit range.
     #   - There is no need to assert a content-position ceiling. An
     #     earlier attempt (#19, removed in v5.3.2) added a ValueError
     #     when content_pos_id climbed into the section range. That

--- a/plugin/kfxgen/native_generator.py
+++ b/plugin/kfxgen/native_generator.py
@@ -2107,9 +2107,12 @@ class NativeKFXGenerator:
     #     duplicates don't break nav.
     #   - Despite (a), the values themselves matter. Pushing
     #     SECTION_POS_BASE up to 100000 broke Kindle's progress display
-    #     ("at start of book" showed 100% complete). The 5-digit range
-    #     v5.2.0 used (≤ 16000-ish for content, 10000+ for sections) is
-    #     the known-good envelope. Don't widen.
+    #     ("at start of book" showed 100% complete). Keep section eids in
+    #     the low 5-digit range Kindle has been observed to handle.
+    #   - The section base is dynamic (#30): SECTION_POS_BASE is the floor,
+    #     but for books whose content overflows it the sections relocate to
+    #     just above content_max (via _section_base) so content and section
+    #     eids stay disjoint. Normal books are unaffected (stay at 10000).
     #   - There is no need to assert a content-position ceiling. An
     #     earlier attempt (#19, removed in v5.3.2) added a ValueError
     #     when content_pos_id climbed into the section range. That
@@ -2123,6 +2126,19 @@ class NativeKFXGenerator:
     CONTENT_POS_STEP = 2  # Position ID step for $259 entries
     SECTION_POS_BASE = 10000  # Position ID base for $260 sections (v5.2.0 known-good)
     SECTION_POS_STEP = 2  # Position ID step for $260 sections
+
+    @classmethod
+    def _section_base(cls, content_max):
+        """Base position id for $260 sections.
+
+        Sections start strictly above the content range so content and
+        section eids never collide (#30). For normal books (content stays
+        under SECTION_POS_BASE) this is the floor SECTION_POS_BASE, keeping
+        output byte-identical; only books whose content would overflow the
+        floor relocate their sections just above content_max. Content eids
+        are always even, so content_max + SECTION_POS_STEP stays even-aligned.
+        """
+        return max(cls.SECTION_POS_BASE, content_max + cls.SECTION_POS_STEP)
 
     @staticmethod
     def _detect_image_dimensions(image_data):
@@ -2437,12 +2453,14 @@ class NativeKFXGenerator:
                 chunk_positions[chunk_idx] = content_pos_id
                 content_pos_id += self.CONTENT_POS_STEP
 
-        # Section position IDs (for $260) — separate range, may arithmetically
-        # collide with chunk positions for busy books (v5.2.0 had ~71 such
-        # collisions on the test corpus and worked correctly).
+        # Section position IDs (for $260). The base is dynamic (#30): sections
+        # start strictly above the content range so content and section eids
+        # are disjoint at any chapter count. Normal books keep SECTION_POS_BASE
+        # (byte-identical); only overflow books relocate.
+        content_max = content_pos_id - self.CONTENT_POS_STEP
+        section_base = self._section_base(content_max)
         section_positions = [
-            self.SECTION_POS_BASE + i * self.SECTION_POS_STEP
-            for i in range(len(chapters))
+            section_base + i * self.SECTION_POS_STEP for i in range(len(chapters))
         ]
 
         # Chapter start positions for TOC entries. These MUST point to a

--- a/plugin/kfxgen/native_generator.py
+++ b/plugin/kfxgen/native_generator.py
@@ -2113,6 +2113,11 @@ class NativeKFXGenerator:
     #     but for books whose content overflows it the sections relocate to
     #     just above content_max (via _section_base) so content and section
     #     eids stay disjoint. Normal books are unaffected (stay at 10000).
+    #     Caveat: a huge book (~1200+ chapters) pushes relocated section eids
+    #     into the ~20k range — believed safe (well under the 100000 that
+    #     broke progress, and content itself already renders near ~18k) but
+    #     NOT yet device-observed at that height. Pending the #30 device gate;
+    #     don't treat ~20k as confirmed-good.
     #   - There is no need to assert a content-position ceiling. An
     #     earlier attempt (#19, removed in v5.3.2) added a ValueError
     #     when content_pos_id climbed into the section range. That

--- a/tests/unit/test_converter.py
+++ b/tests/unit/test_converter.py
@@ -961,20 +961,15 @@ class TestGatsbyShapedSplit:
 
 
 class TestHighChapterCountScale:
-    @pytest.mark.xfail(
-        reason="#30 position-range rework needed at high chapter+chunk counts",
-        strict=True,
-    )
-    def test_1200_chapter_book_converts_and_stays_in_envelope(self, tmp_path):
-        # Measured content_max = 17798 (1200 chapters × 6 paragraphs) — exceeds
-        # SECTION_POS_BASE (10000). Escalate to #30 for position-range rework.
+    """A large book (1200 chapters × several paragraphs) must keep content and
+    section eid ranges disjoint by construction (#30) — no reliance on the
+    old fixed 10000 boundary, which this book's content overflows."""
+
+    def test_1200_chapter_book_has_disjoint_eid_ranges(self, tmp_path):
         from kfxgen.native_generator import NativeKFXGenerator
         from kfxgen.kfxlib_minimal.ion import IS
         from tests._kfx_introspect import by_type, val, load_fragments
 
-        # 1200 chapters, each with 6 paragraphs (~6 content chunks per chapter).
-        # Samples both the chapter axis and the content-chunk axis to find the
-        # realistic worst-case content position id.
         chapters = [
             {
                 "title": f"Chapter {i}",
@@ -995,19 +990,62 @@ class TestHighChapterCountScale:
         )
         frags = load_fragments(out)
 
-        # All $260 sections present.
         assert len(by_type(frags, "$260")) == 1200
 
-        # Content positions stay below SECTION_POS_BASE; sections at/above it.
-        # Measured content_max = 17798 (1200 chapters × 6 paragraphs), which
-        # exceeds SECTION_POS_BASE (10000) — hence xfail; see issue #30.
-        content_max = 0
+        content_eids = set()
         for f in by_type(frags, "$259"):
             v = val(f)
             for e in v.get(IS("$146")) or v.get(IS("$181")) or []:
                 if hasattr(e, "get") and e.get(IS("$155")) is not None:
-                    content_max = max(content_max, int(e.get(IS("$155"))))
-        assert content_max < NativeKFXGenerator.SECTION_POS_BASE, (
-            f"content position {content_max} entered the section range — "
-            f"envelope exceeded; escalate to #30"
+                    content_eids.add(int(e.get(IS("$155"))))
+
+        section_eids = set()
+        for f in by_type(frags, "$260"):
+            v = val(f)
+            for e in v.get(IS("$141")) or []:
+                if hasattr(e, "get") and e.get(IS("$155")) is not None:
+                    section_eids.add(int(e.get(IS("$155"))))
+
+        # Content pushes past the old 10000 floor at this scale...
+        assert max(content_eids) >= NativeKFXGenerator.SECTION_POS_BASE
+        # ...but content and section eid sets are still disjoint by construction.
+        assert content_eids.isdisjoint(section_eids), (
+            f"content/section eid overlap: {sorted(content_eids & section_eids)[:10]}"
         )
+
+        # #23 invariant still holds: every section eid is present in $265.
+        pos_265 = set()
+        for f in by_type(frags, "$265"):
+            v = val(f)
+            entries = v if isinstance(v, list) else v.get(IS("$181")) or []
+            for e in entries:
+                if hasattr(e, "get") and e.get(IS("$185")) is not None:
+                    pos_265.add(int(e.get(IS("$185"))))
+        missing = section_eids - pos_265
+        assert not missing, f"section eids absent from $265: {sorted(missing)[:10]}"
+
+
+# ── Task 1: Dynamic section base (#30) ────────────────────────────────────────
+
+
+class TestSectionBase:
+    def test_normal_book_keeps_default_base(self):
+        from kfxgen.native_generator import NativeKFXGenerator
+
+        # content well under the floor -> sections stay at SECTION_POS_BASE
+        assert NativeKFXGenerator._section_base(3398) == 10000
+        assert NativeKFXGenerator._section_base(9998) == 10000
+
+    def test_overflow_relocates_above_content(self):
+        from kfxgen.native_generator import NativeKFXGenerator
+
+        # content at/above the floor -> section base moves just above content_max
+        assert NativeKFXGenerator._section_base(10000) == 10002
+        assert NativeKFXGenerator._section_base(17798) == 17800
+
+    def test_result_is_even_aligned(self):
+        from kfxgen.native_generator import NativeKFXGenerator
+
+        # content eids are always even; the relocated base stays even
+        for cm in (10000, 10002, 12344, 17798):
+            assert NativeKFXGenerator._section_base(cm) % 2 == 0


### PR DESCRIPTION
## Summary

Follow-on from #23. kfxgen assigned section positions (`$260`) at a fixed `SECTION_POS_BASE = 10000`, while content positions (`$259`) grow with chapters + chunks. For very large books (~1,200 chapters) content climbs past 10,000 and collides with the section range — jhowell's reader logs `duplicate eid …`. #23 left an `xfail` scale gate pointing here.

This makes the section base **dynamic** so content and section eid ranges are **disjoint by construction at any chapter count**, while keeping normal books byte-identical.

## Approach (Option 1: provable no-overlap, low-risk-first)

- Add `NativeKFXGenerator._section_base(content_max) = max(SECTION_POS_BASE, content_max + SECTION_POS_STEP)`.
- Compute `content_max` (the last assigned content eid) after the content loop and build `section_positions` from the dynamic base.
- Normal books (content < 10,000) → base stays `10,000` → **byte-identical output** (golden bytes unchanged, no re-verification).
- Overflow books → sections relocate just above the content range (minimal padding, keeping section eids as low as possible).
- The guarantee is asserted as content∩section eid-set **disjointness** (replacing the fixed-10,000 threshold); the #23 scale `xfail` is removed.

Content positions and their assignment are unchanged; `_section_base` is the only behavioral edit.

## Verification

- **Decode (upstream `kfxlib`):** a 1,170-chapter book (Complete Works of Shakespeare) went from **1,141 `duplicate eid` warnings → 0**; 0 position/location-map errors.
- **Device-verified:** that book (section eids relocated to ~20k) navigates correctly on a physical Kindle — late-chapter TOC taps land on target and the progress readout is sane (88% at a late play). Normal books are byte-identical, so no re-verification for the common case.
- **444 passed, 12 skipped, 0 xfail** (the scale test now passes asserting disjointness); golden bytes unchanged; ruff (0.15.1) clean.

Bumps 5.3.22 → 5.3.23. Closes #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)