### PR TITLE
Capture inherited text-align in real conversions (#33)

### DIFF
--- a/plugin/kfxgen/converter.py
+++ b/plugin/kfxgen/converter.py
@@ -40,29 +40,41 @@ def _computed_value(style, prop):
         return style.get(prop)
 
 
-def _build_style_resolver(oeb_book, item, log):
+def _default_stylizer(oeb_book, item):
+    from calibre.ebooks.oeb.stylizer import Stylizer  # noqa: PLC0415
+
+    profile = getattr(getattr(oeb_book, "opts", None), "output_profile", None)
+    return Stylizer(item.data, item.href, oeb_book, oeb_book.opts, profile)
+
+
+def _build_style_resolver(oeb_book, item, log, stylizer_factory=None):
     """Return a callable elem->computed-CSS-dict using Calibre's Stylizer, or
     None when Calibre/Stylizer is unavailable or construction fails. Never
-    raises — failure degrades to no per-element block styling."""
-    try:
-        from calibre.ebooks.oeb.stylizer import Stylizer  # noqa: PLC0415
+    raises — failure degrades to no per-element block styling.
 
-        profile = getattr(getattr(oeb_book, "opts", None), "output_profile", None)
-        stylizer = Stylizer(item.data, item.href, oeb_book, oeb_book.opts, profile)
+    `stylizer_factory(oeb_book, item)` is injectable for tests; the default
+    builds Calibre's Stylizer."""
+    try:
+        make = stylizer_factory or _default_stylizer
+        stylizer = make(oeb_book, item)
 
         def resolve(elem):
             try:
                 st = stylizer.style(elem)
                 return {
-                    "text-align": st.get("text-align"),
+                    # text-align is INHERITED (set on <body> or a wrapper
+                    # <div>), so read it inheritance-aware like font-family:
+                    # Style.get() returns None when inherited; Style[prop]
+                    # returns the computed value ('auto' when truly unset,
+                    # which ALIGN_MAP ignores). text-indent/margins stay on
+                    # .get(): margins don't inherit, and getitem drops the CSS
+                    # unit on indent (returns computed px).
+                    "text-align": _computed_value(st, "text-align"),
                     "text-indent": st.get("text-indent"),
                     "margin-left": st.get("margin-left"),
                     "margin-right": st.get("margin-right"),
-                    # font-family/-weight/-style are INHERITED CSS properties,
-                    # usually set on <body> and inherited by paragraphs.
-                    # Style.get() returns only element-local values (None when
-                    # inherited); Style[prop] returns the computed value. Use
-                    # getitem so ancestor-declared emphasis/fonts apply.
+                    # font-family/-weight/-style are also inherited, usually set
+                    # on <body> and inherited by paragraphs.
                     "font-family": _computed_value(st, "font-family"),
                     "font-weight": _computed_value(st, "font-weight"),
                     "font-style": _computed_value(st, "font-style"),

--- a/tests/unit/test_converter.py
+++ b/tests/unit/test_converter.py
@@ -1127,3 +1127,59 @@ def test_computed_value_prefers_getitem_for_inherited():
 def test_computed_value_falls_back_to_get_when_getitem_missing():
     st = _FakeStyle(own={"font-family": "Georgia"}, computed={})
     assert _conv._computed_value(st, "font-family") == "Georgia"
+
+
+# --- #33: text-align inherited from <body>/<div> must not be dropped ---
+
+
+class _FakeCalibreStyle:
+    """Mimics Calibre's Style: .get() is element-local only (None when
+    inherited); [prop] returns the computed value (incl. inheritance)."""
+
+    def __init__(self, own, computed):
+        self._own, self._computed = own, computed
+
+    def get(self, k, default=None):
+        return self._own.get(k, default)
+
+    def __getitem__(self, k):
+        if k in self._computed:
+            return self._computed[k]
+        raise KeyError(k)
+
+
+class _FakeStylizer:
+    def __init__(self, style):
+        self._style = style
+
+    def style(self, elem):
+        return self._style
+
+
+@pytest.mark.unit
+def test_style_resolver_reads_inherited_text_align_via_getitem():
+    # Regression for #33: text-align set on <body>/<div> is inherited; Calibre's
+    # Style.get() returns None for it, Style[prop] returns 'center'. The resolver
+    # must use getitem so inherited alignment isn't silently dropped.
+    st = _FakeCalibreStyle(own={}, computed={"text-align": "center"})
+    resolver = _conv._build_style_resolver(
+        None,
+        None,
+        _silent_log(),
+        stylizer_factory=lambda oeb, item: _FakeStylizer(st),
+    )
+    assert resolver(object())["text-align"] == "center"
+
+
+@pytest.mark.unit
+def test_style_resolver_unstyled_align_is_auto_then_ignored():
+    # A truly unstyled paragraph: getitem returns 'auto', which compute_block_style
+    # must ignore (so getitem does not over-apply alignment).
+    st = _FakeCalibreStyle(own={}, computed={"text-align": "auto"})
+    resolver = _conv._build_style_resolver(
+        None, None, _silent_log(), stylizer_factory=lambda oeb, item: _FakeStylizer(st)
+    )
+    assert resolver(object())["text-align"] == "auto"
+    from kfxgen.inline_style import compute_block_style
+
+    assert compute_block_style({"text-align": "auto"})["align"] is None


### PR DESCRIPTION
## Capture inherited `text-align` in real conversions (#33)

Closes #33.

#33 asked whether block-level CSS actually applies in real Calibre conversions
after the `_ensure_oeb_opts` fix (from #15) restored the Stylizer. Verifying it
confirmed the Stylizer now runs — but the audit found a **second latent bug in
the same class as the font-family one**: the per-element style resolver read
`text-align` via Calibre's `Style.get()`, which returns `None` for values
**inherited** from `<body>` or a wrapper `<div>`. So any book that sets alignment
on an ancestor (centered title pages, centered verse, `<div class="center">`, …)
**lost its alignment** in every real conversion and fell back to justify.

### Fix

- Read `text-align` inheritance-aware via `_computed_value` (getitem), like
  font-family. getitem returns the computed keyword, and `'auto'` for a truly
  unstyled paragraph — which `ALIGN_MAP` ignores, so there is no over-application.
- `text-indent` and margins stay on `.get()`: margins don't inherit, and getitem
  drops the CSS unit on indent (returns computed px). *Known minor gap:*
  inherited `text-indent` (rare) is still not captured — deferred rather than
  risk a unit regression.

### Test coverage (the gap that let this hide)

No test exercised the **real** Stylizer — the existing block-style test
monkeypatches a fake resolver, and the golden corpus uses the Calibre-free
`EpubAsOeb` shim, so the resolver's `.get()`-vs-getitem behavior was never
covered. This PR makes `_build_style_resolver` accept an injectable
`stylizer_factory`, and adds unit tests that drive the inheritance path with a
fake Calibre `Style` (`.get()` → `None`, `[prop]` → value). These **fail if the
resolver is reverted to `.get()`** and run in CI without Calibre.

### Verification

- End-to-end via the real Calibre Stylizer + `kfxlib` decode: a wrapper-`<div>`
  centered paragraph now emits `$34 = $320` (center); an unstyled paragraph stays
  justify; both centered paragraphs share one identical `$157` style (no spurious
  indent).
- **Device-confirmed:** direct and inherited centering both render on a physical
  Kindle.
- 497 tests pass; `tier3_strict` goldens byte-identical; both ruff gates clean.

### Context

- Follow-up to #15 (the `_ensure_oeb_opts` fix is what re-enabled the Stylizer,
  exposing this). Block-level alignment was silently dropped in real conversions
  before this, so #9's block CSS was likely never truly device-verified — this
  closes that loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
