### PR TITLE
release: v5.4.1 — fix dropped inherited text-align (#33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 5.4.1 — Fix dropped inherited text-align (#33)
+
+Block-level `text-align` set on `<body>` or a wrapping `<div>` (centered title
+pages, centered verse, `<div class="center">`, …) was silently dropped in real
+Calibre conversions and fell back to justify. The style resolver read it via
+Calibre's `Style.get()`, which returns `None` for inherited values; it now reads
+`text-align` inheritance-aware via `Style[prop]` (like font-family), with the
+`auto` default ignored so unstyled paragraphs are unaffected. Margins and
+`text-indent` are unchanged (margins don't inherit; getitem drops the CSS unit on
+indent).
+
+`_build_style_resolver` gained an injectable stylizer factory so the inheritance
+behavior is unit-tested without Calibre — closing the gap that let this hide
+(no test exercised the real Stylizer). Device-verified: direct and inherited
+centering both render on a physical Kindle. No-font/no-style output is
+byte-identical (tier3_strict golden corpus unchanged).
+
 ## 5.4.0 — Embedded font support (#15)
 
 Fonts declared in a source EPUB via `@font-face` now travel inside the `.kfx`

--- a/plugin/kfxgen/__init__.py
+++ b/plugin/kfxgen/__init__.py
@@ -12,7 +12,7 @@ __copyright__ = "2025-2026, Justin Loutsch <justin.loutsch@gmail.com>"
 
 #: Version tuple. Bump this for every release; the plugin wrapper and
 #: converter log message read from here.
-version = (5, 4, 0)
+version = (5, 4, 1)
 __version__ = ".".join(str(x) for x in version)
 
 __all__ = [


### PR DESCRIPTION
Version bump + CHANGELOG for the inherited `text-align` fix already merged in #38.

- `plugin/kfxgen/__init__.py`: 5.4.0 → 5.4.1
- CHANGELOG: 5.4.1 entry

Once merged, `v5.4.1` will be tagged to publish the GitHub Release (per the
tag-triggered `release.yml`). No code change beyond version + changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)