### PR TITLE
release: v5.4.2 — distinct slugs for non-ASCII embedded fonts (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 5.4.2 — Distinct slugs for non-ASCII embedded fonts (#36)
+
+Fixes internal font-family names for embedded fonts whose `@font-face` family is
+non-ASCII (CJK, Cyrillic, …). The slug builder kept only `[a-z0-9]`, so such
+names lost all identity and collapsed to a generic `font` base — distinct
+families (e.g. Korean 명조 serif vs 고딕 sans) were separated only by an
+incrementing dedup counter, a fragile scheme where a font shared under two
+family names could mis-map. Names containing non-ASCII characters now get a
+short stable hash of the full name appended, so distinct families get distinct
+slug bases. Pure-ASCII names are unchanged (byte-identical output for the common
+case; tier3_strict golden corpus unchanged). Rendering was already correct on
+device — this hardens correctness and makes decoded output legible.
+
 ## 5.4.1 — Fix dropped inherited text-align (#33)
 
 Block-level `text-align` set on `<body>` or a wrapping `<div>` (centered title

--- a/plugin/kfxgen/__init__.py
+++ b/plugin/kfxgen/__init__.py
@@ -12,7 +12,7 @@ __copyright__ = "2025-2026, Justin Loutsch <justin.loutsch@gmail.com>"
 
 #: Version tuple. Bump this for every release; the plugin wrapper and
 #: converter log message read from here.
-version = (5, 4, 1)
+version = (5, 4, 2)
 __version__ = ".".join(str(x) for x in version)
 
 __all__ = [

--- a/plugin/kfxgen/font_table.py
+++ b/plugin/kfxgen/font_table.py
@@ -4,6 +4,7 @@ Isolated from the generator so the risky parsing/matching logic is unit-tested
 without Calibre. Calibre only appears in build_font_table (Task 4).
 """
 
+import hashlib
 import re
 from dataclasses import dataclass
 
@@ -70,7 +71,16 @@ def extract_src_urls(src):
 
 
 def _slug(name):
-    out = re.sub(r"[^a-z0-9]+", "-", normalize_family(name)).strip("-")
+    norm = normalize_family(name)
+    out = re.sub(r"[^a-z0-9]+", "-", norm).strip("-")
+    # Non-ASCII family names (CJK, Cyrillic, ...) lose all identity to the
+    # ASCII-only slug, so distinct families (e.g. Korean 명조 serif vs 고딕 sans)
+    # would collapse to the same base and rely only on emitted_name's dedup
+    # counter to stay apart. Append a short, stable hash of the full name so
+    # distinct families get distinct slug bases. Pure-ASCII names are unchanged.
+    if any(ord(c) > 127 for c in norm):
+        h = hashlib.sha1(norm.encode("utf-8")).hexdigest()[:8]
+        out = f"{out}-{h}" if out else f"font-{h}"
     return out or "font"
 
 

--- a/tests/unit/test_font_table.py
+++ b/tests/unit/test_font_table.py
@@ -9,6 +9,7 @@ from kfxgen.font_table import (
     faces_from_rules,
     is_ttf_otf,
     normalize_family,
+    _slug,
     parse_style,
     parse_weight,
 )
@@ -294,3 +295,35 @@ def test_build_font_table_empty_when_no_fonts():
     oeb = _Oeb([], spine=[object()])
     table = build_font_table(oeb, _Log(), stylizer_factory=lambda item: _Stylizer([]))
     assert table.faces == []
+
+
+# --- #36: non-ASCII @font-face family names must yield distinct, stable slugs ---
+
+
+def test_slug_ascii_names_unchanged():
+    assert _slug("KoPubBatang") == "kopubbatang"
+    assert _slug('"Merriweather"') == "merriweather"
+    assert _slug("Times New Roman") == "times-new-roman"
+    assert _slug("") == "font"
+
+
+def test_slug_non_ascii_families_distinct_and_stable():
+    a, b = _slug("명조"), _slug("고딕")  # Korean: Myeongjo (serif) / Gothic (sans)
+    assert a != b  # was: both collapse to "font"
+    assert a != "font" and b != "font"
+    assert a == _slug("명조")  # deterministic across calls
+    assert a.startswith("font-")
+
+
+def test_slug_mixed_ascii_cjk_keeps_ascii_base_but_disambiguates():
+    m1, m2 = _slug("KoPub 명조"), _slug("KoPub 고딕")
+    assert m1 != m2
+    assert m1.startswith("kopub-") and m2.startswith("kopub-")
+
+
+def test_emitted_name_non_ascii_bases_are_distinct_not_counter_suffixed():
+    taken = set()
+    a = emitted_name("명조", 700, False, taken)
+    b = emitted_name("고딕", 700, False, taken)
+    assert a != b
+    assert not b.endswith("-1")  # distinct by identity, not the dedup counter


### PR DESCRIPTION
Closes #36.

`_slug()` kept only `[a-z0-9]`, so non-ASCII `@font-face` family names (CJK,
Cyrillic) lost all identity and collapsed to a generic `font` base — distinct
families stayed apart only via `emitted_name`'s dedup counter (fragile). Now a
name containing non-ASCII characters gets a short stable SHA-1 hash of the full
normalized name appended, so distinct families get distinct slug bases.
Pure-ASCII names are unchanged.

- **Verified on a real Korean EPUB:** the two embedded families now emit distinct
  bases (`font-47a9f002-*` / `font-bb624abf-*`) instead of colliding on `font`.
- CI-runnable unit tests (CJK distinct/stable; ASCII unchanged).
- Byte-identical output for no-font/ASCII books (`tier3_strict` green).
- Includes the 5.4.1 -> 5.4.2 bump + CHANGELOG; tag `v5.4.2` after merge to
  publish the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)