### PR TITLE
refactor: single Calibre Stylizer builder (#41)

### DIFF
--- a/plugin/kfxgen/converter.py
+++ b/plugin/kfxgen/converter.py
@@ -41,10 +41,10 @@ def _computed_value(style, prop):
 
 
 def _default_stylizer(oeb_book, item):
-    from calibre.ebooks.oeb.stylizer import Stylizer  # noqa: PLC0415
+    # Single source of the Stylizer signature lives in font_table (#41).
+    from .font_table import build_stylizer  # noqa: PLC0415
 
-    profile = getattr(getattr(oeb_book, "opts", None), "output_profile", None)
-    return Stylizer(item.data, item.href, oeb_book, oeb_book.opts, profile)
+    return build_stylizer(oeb_book, item)
 
 
 def _build_style_resolver(oeb_book, item, log, stylizer_factory=None):

--- a/plugin/kfxgen/font_table.py
+++ b/plugin/kfxgen/font_table.py
@@ -223,13 +223,25 @@ def build_manifest_lookup(oeb_book):
     return lookup
 
 
+def build_stylizer(oeb_book, item):
+    """Construct Calibre's Stylizer for one OEB spine item.
+
+    Single home for the version-sensitive `Stylizer(tree, path, oeb, opts,
+    profile)` signature (#41) — shared by @font-face extraction here and the
+    per-element style resolver in converter.py, so a Calibre-side signature
+    change only needs updating in one place. Raises if Calibre is unavailable;
+    callers decide how to degrade.
+    """
+    from calibre.ebooks.oeb.stylizer import Stylizer  # noqa: PLC0415
+
+    profile = getattr(getattr(oeb_book, "opts", None), "output_profile", None)
+    return Stylizer(item.data, item.href, oeb_book, oeb_book.opts, profile)
+
+
 def _default_stylizer_factory(oeb_book, log):
     def make(item):
         try:
-            from calibre.ebooks.oeb.stylizer import Stylizer  # noqa: PLC0415
-
-            profile = getattr(getattr(oeb_book, "opts", None), "output_profile", None)
-            return Stylizer(item.data, item.href, oeb_book, oeb_book.opts, profile)
+            return build_stylizer(oeb_book, item)
         except Exception as e:
             log.warning(f"  Stylizer unavailable for fonts ({e})")
             return None

--- a/tests/unit/test_font_table.py
+++ b/tests/unit/test_font_table.py
@@ -327,3 +327,21 @@ def test_emitted_name_non_ascii_bases_are_distinct_not_counter_suffixed():
     b = emitted_name("고딕", 700, False, taken)
     assert a != b
     assert not b.endswith("-1")  # distinct by identity, not the dedup counter
+
+
+# --- #41: single Stylizer builder; factory degrades cleanly without Calibre ---
+
+
+def test_build_stylizer_and_factory_degrade_without_calibre():
+    from kfxgen.font_table import _default_stylizer_factory
+
+    class _Item:
+        data = None
+        href = "c.xhtml"
+
+    log = _Log()
+    make = _default_stylizer_factory(object(), log)
+    # No Calibre in the test env -> build_stylizer raises -> factory returns None
+    # and warns, rather than propagating.
+    assert make(_Item()) is None
+    assert log.warns


### PR DESCRIPTION
Closes #41.

The version-sensitive `Stylizer(item.data, item.href, oeb_book, oeb_book.opts,
profile)` construction was duplicated in `converter._default_stylizer` and
`font_table._default_stylizer_factory`. Extracts `build_stylizer(oeb_book, item)`
in `font_table` as the single home for that signature; both callers delegate, so
a Calibre-side change updates one place. Ties off the drift concern noted in #18.

- `Stylizer(...)` now constructed in exactly one spot.
- Adds a runnable test that the factory degrades to `None` + warn without Calibre.
- **No behavior change** — full suite + tier3_strict goldens unchanged. No
  version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)