### PR TITLE
release: v5.4.3 — cap embedded font size (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 5.4.3 — Cap embedded font size (#47)
+
+Security hardening surfaced by a whole-project review. Embedded fonts had no size
+limit — `build_fragment_418` wrapped raw manifest font bytes in a BLOB and
+`faces_from_rules` only checked TTF/OTF magic bytes. A valid-magic but oversized
+"font" in an untrusted EPUB was embedded wholesale (memory spike during conversion
++ oversized `.kfx`). `faces_from_rules` now skips + warns any face exceeding
+`max_font_bytes` (default 50 MB, override via `KFXGEN_MAX_FONT_BYTES`) — generous
+enough for large CJK faces (~10-20 MB) while bounding the pathological case. Brings
+the font pipeline in line with the image pipeline's existing input cap. Low
+severity under the single-user threat model; no impact on legitimate books
+(verified a real Korean book still embeds all four KoPub faces).
+
 ## 5.4.2 — Distinct slugs for non-ASCII embedded fonts (#36)
 
 Fixes internal font-family names for embedded fonts whose `@font-face` family is

--- a/plugin/kfxgen/__init__.py
+++ b/plugin/kfxgen/__init__.py
@@ -12,7 +12,7 @@ __copyright__ = "2025-2026, Justin Loutsch <justin.loutsch@gmail.com>"
 
 #: Version tuple. Bump this for every release; the plugin wrapper and
 #: converter log message read from here.
-version = (5, 4, 2)
+version = (5, 4, 3)
 __version__ = ".".join(str(x) for x in version)
 
 __all__ = [

--- a/plugin/kfxgen/font_table.py
+++ b/plugin/kfxgen/font_table.py
@@ -5,8 +5,27 @@ without Calibre. Calibre only appears in build_font_table (Task 4).
 """
 
 import hashlib
+import os
 import re
 from dataclasses import dataclass
+
+
+def _int_env(name, default):
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+#: Per-face cap on embedded font bytes (#47). Blocks resource exhaustion from a
+#: valid-magic but oversized "font" in an untrusted EPUB. 50 MB sits well above
+#: any legitimate face — even full-coverage CJK fonts run ~10-20 MB — while
+#: bounding the pathological case. Override via KFXGEN_MAX_FONT_BYTES.
+MAX_FONT_BYTES = _int_env("KFXGEN_MAX_FONT_BYTES", 50 * 1024 * 1024)
 
 # TrueType/OpenType magic bytes. WOFF (wOFF) / WOFF2 (wOF2) are intentionally
 # excluded — Kindle cannot embed them and decoding needs deps we don't carry.
@@ -114,11 +133,12 @@ def rule_field(rule, key):
     return None
 
 
-def faces_from_rules(rules, manifest_lookup, log):
+def faces_from_rules(rules, manifest_lookup, log, max_font_bytes=MAX_FONT_BYTES):
     """Turn @font-face rule dicts + a manifest byte-lookup into Face objects.
 
-    Skips (with a warning) rules whose family is missing or whose only
-    resolvable src bytes are not TTF/OTF. Dedups by resolved href.
+    Skips (with a warning) rules whose family is missing, whose only resolvable
+    src bytes are not TTF/OTF, or whose font exceeds `max_font_bytes` (#47 —
+    resource-exhaustion defense). Dedups by resolved href.
     """
     faces = []
     taken_names = set()
@@ -134,9 +154,17 @@ def faces_from_rules(rules, manifest_lookup, log):
         chosen_data = None
         for href in extract_src_urls(rule_field(rule, "src")):
             data = manifest_lookup(href)
-            if data and is_ttf_otf(data):
-                chosen_href, chosen_data = href, data
-                break
+            if not (data and is_ttf_otf(data)):
+                continue
+            if len(data) > max_font_bytes:
+                log.warn(
+                    f"  Skipping @font-face {family!r} src {href!r}: "
+                    f"{len(data)} bytes exceeds the {max_font_bytes}-byte cap "
+                    f"(KFXGEN_MAX_FONT_BYTES)"
+                )
+                continue
+            chosen_href, chosen_data = href, data
+            break
         if chosen_data is None:
             log.warn(
                 f"  Skipping @font-face {family!r}: no embeddable TTF/OTF src "

--- a/tests/unit/test_font_table.py
+++ b/tests/unit/test_font_table.py
@@ -345,3 +345,39 @@ def test_build_stylizer_and_factory_degrade_without_calibre():
     # and warns, rather than propagating.
     assert make(_Item()) is None
     assert log.warns
+
+
+# --- #47: cap embedded font size (resource-exhaustion defense) ---
+
+
+def test_faces_from_rules_skips_oversized_font():
+    log = _Log()
+    big = b"\x00\x01\x00\x00" + b"x" * 200  # valid TTF magic, 204 bytes
+    rules = [{"font-family": "Foo", "src": "url(f.ttf)"}]
+    manifest = _mk_manifest({"f.ttf": big})
+    faces = faces_from_rules(rules, manifest, log, max_font_bytes=100)
+    assert faces == []
+    assert any(
+        "large" in w.lower() or "exceed" in w.lower() or "cap" in w.lower()
+        for w in log.warns
+    )
+
+
+def test_faces_from_rules_accepts_font_within_cap():
+    log = _Log()
+    ok = b"\x00\x01\x00\x00yy"
+    faces = faces_from_rules(
+        rules=[{"font-family": "Foo", "src": "url(f.ttf)"}],
+        manifest_lookup=_mk_manifest({"f.ttf": ok}),
+        log=log,
+        max_font_bytes=1000,
+    )
+    assert len(faces) == 1
+
+
+def test_default_max_font_bytes_allows_large_cjk_faces():
+    # Must not reject legitimate large CJK fonts (tens of MB). Default cap must
+    # sit well above a real CJK face.
+    from kfxgen.font_table import MAX_FONT_BYTES
+
+    assert MAX_FONT_BYTES >= 30 * 1024 * 1024


### PR DESCRIPTION
Closes #47.

Security hardening from the whole-project review: embedded fonts had no size cap
(`build_fragment_418` + `faces_from_rules` only checked magic bytes), so a
valid-magic oversized "font" in an untrusted EPUB was embedded wholesale.
`faces_from_rules` now skips + warns any face over `max_font_bytes` (default
50 MB, `KFXGEN_MAX_FONT_BYTES` override) — generous for large CJK faces, bounds
the pathological case. Mirrors the image pipeline's input cap.

- CI-runnable tests: oversized skipped + warns; within-cap accepted; default cap
  ≥ 30 MB so CJK isn't rejected.
- Verified a real Korean book still embeds all 4 KoPub faces under the cap.
- Includes 5.4.2 → 5.4.3 bump + CHANGELOG; tag `v5.4.3` after merge to release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)