### PR TITLE
chore: ignore throwaway research-corpus analysis scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,24 @@ Kindle Previewer*.app/
 VERSION_*.md
 TEMPLATE_APPROACH_PLAN.md
 
+# Throwaway analysis of the local research corpus. These scripts open books
+# from the maintainer's gitignored research/ directory, so they carry real
+# titles and author names in hardcoded paths — exactly what must not reach a
+# public repo. They normally live outside the tree entirely (a scratch dir
+# under /tmp); these rules are the backstop for when one gets copied in.
+# Root-anchored like the block above, so real source keeps its names free:
+# tools/inspect_font_face_rules.py is unaffected.
+# `scratchpad/` is the reliable one — name-based patterns only catch the
+# common shapes, so put throwaway scripts in a scratchpad dir rather than
+# trusting the list below to have guessed the filename.
+scratchpad/
+/inspect*.py
+/*probe*.py
+/dump_*.py
+/check_*.py
+/*_check.py
+/*-investigation.md
+
 # Gutenberg baseline corpus (large; not for git)
 research/gutenberg-top-90/
 research/gutenberg-top-90-baseline/*/


### PR DESCRIPTION
Follow-up hygiene from the #51–#53 investigation. Independent of #54 — branched off `main` so it can merge on its own.

## Why

Ad-hoc scripts written while investigating a bug open books from the maintainer's gitignored `research/` directory, so they carry real titles and author names in hardcoded paths.

Nothing has leaked. An audit covering every blob in every commit on all branches, all commit messages, tracked content, and the filed issues + PR came back clean. But the only thing keeping these files out was that they live outside the tree, under a scratch dir in `/tmp`. That protection is **positional, not enforced** — it evaporates the moment one is copied in. Before this change, `cover_probe.py`, `jpeg_probe.py`, `inspect*.py` and the investigation notes were all freely committable at repo root.

## What

Extends the existing "Development scripts" block in its established root-anchored style:

```
scratchpad/
/inspect*.py
/*probe*.py
/dump_*.py
/check_*.py
/*_check.py
/*-investigation.md
```

`scratchpad/` is the rule that actually holds. The name patterns are a backstop for common shapes and **cannot be complete** — one script from the session (`build_cover_ab.py`) is still not caught by name, and that is the point of the comment telling you to use a scratchpad dir rather than trust the list. I chose not to chase it with an ever-growing pattern list.

## Verified

- **0** currently tracked files are shadowed by any new rule (an ignore rule matching a tracked file is a footgun — it stays tracked but behaves confusingly).
- `tools/inspect_font_face_rules.py` unaffected — the rules are root-anchored, and there are no tracked `.py` files at repo root at all.
- 13 of 14 scratch files from this session now caught by name; the 14th by `scratchpad/`.
- Full suite green: 509 passed, 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)