### PR TITLE
fix: gate image optimization on byte size, not just dimensions (#55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,45 @@ uses the test shim and so only exercises the `<sup>` tag route. The resolver
 contract is unit-tested with an injected stylizer, as with the other CSS
 properties.
 
+### Image optimization gates on byte size (#55)
+
+Image optimization only ever triggered on pixel dimensions:
+
+```python
+if max(size) <= max_dim:   # DEFAULT_MAX_DIM = 2048
+    return data
+```
+
+An image can sit well inside that budget and still be far too heavy — encoded
+near-lossless, with EXIF, Photoshop and ICC blocks attached. A 1161x1800 cover
+ran to 2.25 MB and passed through untouched, and because *every* image in that
+book was under 2048px, **not one of its 16 images was optimized — 7.7 MB
+embedded verbatim.**
+
+`optimize_image` now has two independent triggers: dimensions over `max_dim`, or
+encoded weight over `max_bytes` (default 1 MiB, override with
+`KFXGEN_IMAGE_MAX_BYTES`). When only the byte trigger fires the image is
+re-encoded **at its existing dimensions** — it is too heavy, not too big, and
+shrinking it would lose detail for no reason. The existing guard against
+returning something larger than the input still applies.
+
+The default is deliberately generous. Measured across the reference corpus (212
+images in three Amazon-produced KFX files) the largest single image is 466 KB and
+none exceeds 512 KB, so 1 MiB is roughly twice the observed ceiling: it catches
+the pathological tail without recompressing images that are merely large. Set
+`KFXGEN_IMAGE_MAX_BYTES=512000` to track Amazon's own output more tightly.
+
+On the book that surfaced this: 7,677,756 → 4,350,071 bytes (43% smaller, no
+dimension changes), cover 2,254,253 → 490,594.
+
+**Not claimed:** that this fixes the reported "cover does not display on Kindle".
+That symptom is what surfaced the defect, and the sizes are conspicuous, but the
+causal link is unconfirmed — the competing explanation is the unusual
+EXIF/Photoshop/ICC header stack rather than the byte count. Both are resolved by
+re-encoding, so the fix is the same either way. A controlled A/B (identical
+build, single env var) is pending a device sideload to settle it.
+
+
 ## 5.5.0 — Font-embedding toggle (#15) + bold/italic face fix (#50)
 
 **Fixed (#50):** bold and italic embedded faces now render on-device. The applied

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,12 +79,20 @@ the pathological tail without recompressing images that are merely large. Set
 On the book that surfaced this: 7,677,756 → 4,350,071 bytes (43% smaller, no
 dimension changes), cover 2,254,253 → 490,594.
 
-**Not claimed:** that this fixes the reported "cover does not display on Kindle".
-That symptom is what surfaced the defect, and the sizes are conspicuous, but the
-causal link is unconfirmed — the competing explanation is the unusual
-EXIF/Photoshop/ICC header stack rather than the byte count. Both are resolved by
-re-encoding, so the fix is the same either way. A controlled A/B (identical
-build, single env var) is pending a device sideload to settle it.
+**Device-verified.** Sideloading a controlled pair (identical build and book,
+differing only by `KFXGEN_IMAGE_MAX_BYTES`, with distinct titles and ASINs so the
+Kindle could not dedupe them) confirmed it: the 2.25 MB cover does not render, the
+490 KB one does.
+
+The failure turned out to be narrower than expected. The **library thumbnail
+displays for both** — it is only the full-page in-book cover render that fails on
+the heavy image, so that path is evidently on a tighter decode budget than
+whatever generates thumbnails.
+
+One thing this does *not* isolate: re-encoding changed two variables at once, the
+byte count and the ~20 KB of EXIF/Photoshop/ICC/Adobe headers the original
+carried. Either could be the mechanism. The fix resolves both, but a small
+image bloated only by headers would slip past a byte-size gate.
 
 
 ## 5.5.0 — Font-embedding toggle (#15) + bold/italic face fix (#50)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 5.6.0 — Working footnotes: anchors, superscript, in-body links (#51, #52, #53)
+## 5.6.0 — Working footnotes, TOC extraction, and image weight
 
 Footnote markers now render as superscripts and jump to their notes, and the
 Contents page links work. Three separate defects, found by diffing a generated
@@ -94,6 +94,64 @@ byte count and the ~20 KB of EXIF/Photoshop/ICC/Adobe headers the original
 carried. Either could be the mechanism. The fix resolves both, but a small
 image bloated only by headers would slip past a byte-size gate.
 
+
+### TOC extraction: nested lists, tail flags, hidden navs (#58, #59, #60)
+
+Three defects that a device report of a broken contents page exposed. All three
+predate this release — verified by extracting the same damage from an older
+`.kfx` — and the in-body link work above only made them visible, by rendering
+them as underlined links instead of anonymous text.
+
+**#58** `ol`/`ul` were missing from the block-tag set, so an `<li>` holding a
+nested list looked childless and the whole sub-list flattened into one
+paragraph: a Part heading and every chapter under it on a single line. Fixing
+that exposed the other half of the same bug — a container's own inline text was
+*dropped* whenever it also had block children, so `<div>lead-in<p>…</p></div>`
+silently lost "lead-in". Inline runs now flush as their own blocks in document
+order.
+
+**#59** is the broadest fix here and had nothing to do with tables of contents.
+A child's tail text was given the *incoming* flags instead of the enclosing
+element's, so anything after a nested tag lost what its parent contributed —
+` gamma` in `<em>alpha <b>beta</b> gamma</em>` was never italic. Emphasis has
+been quietly wrong since inline emphasis shipped; a missing italic is just
+easier to overlook than a half-underlined link.
+
+**#60** `hidden="hidden"` navs were extracted as body text. An EPUB 3
+`page-list` holds one entry per printed page, which arrived as several hundred
+blocks of bare page numbers after the contents.
+
+### Back-matter and whole-file link targets (#62)
+
+Six TOC entries were inert on device — Afterword, Bibliography, Notes, Also by,
+About the Author, Discover More. Extraction was correct in every case; the
+anchors were lost between the chapter list and the chunk list, so `$179` had
+nothing to resolve. Three paths: a back-matter file opening with a heading equal
+to its chapter title had that block elided as redundant, taking the linked id
+with it; image blocks never carried their anchor ids, so figure links resolved
+to nothing; and whole-file targets (`<a href="about.xhtml">`) only resolved when
+the target file happened to declare some id.
+
+### Corpus verification
+
+The Gutenberg top-90 was converted through both a 5.5.0 baseline and this
+release, in isolated Calibre configurations — 180 conversions, no failures.
+
+| | 5.5.0 | 5.6.0 |
+|---|---|---|
+| anchors carrying `$180` | 0 | 64,820 |
+| link spans | 48,498 | 74,606 |
+| dangling targets | 48,498 (all) | 0 |
+| books losing text | — | 0 |
+
+Every internal link kfxgen has ever emitted resolved against nothing. Seven
+books also *gained* text, verified as recovery rather than duplication (no block
+duplicated, none lost): one had 44% of its body text silently discarded by the
+container bug in #58.
+
+All of the above is device-verified on a physical Kindle. Subscript (a negative
+`$31` shift) is the one exception — no reference file uses one, so it remains
+unverified.
 
 ## 5.5.0 — Font-embedding toggle (#15) + bold/italic face fix (#50)
 

--- a/plugin/kfxgen/image_optimize.py
+++ b/plugin/kfxgen/image_optimize.py
@@ -12,6 +12,20 @@ import struct
 DEFAULT_MAX_DIM = 2048
 DEFAULT_JPEG_QUALITY = 85
 
+#: Byte ceiling above which an image is re-encoded even when its pixel
+#: dimensions are already acceptable (#55). Dimensions alone are a poor proxy
+#: for weight: a 1161x1800 cover encoded near-lossless, with EXIF + Photoshop
+#: + ICC baggage attached, ran to 2.25 MB and sailed through the dimension
+#: gate untouched — as did every other image in that book, 7.7 MB in total.
+#:
+#: Measured against the reference corpus (212 images across three
+#: Amazon-produced KFX files): the largest is 466 KB and not one exceeds
+#: 512 KB. 1 MiB is therefore deliberately generous — roughly twice the
+#: observed ceiling — so it catches the pathological tail without
+#: re-compressing images that are merely large. Lower it via
+#: KFXGEN_IMAGE_MAX_BYTES to track Amazon's own output more tightly.
+DEFAULT_MAX_BYTES = 1024 * 1024
+
 _PNG_SIG = b"\x89PNG\r\n\x1a\n"
 # JPEG Start-Of-Frame markers that carry image dimensions.
 _SOF_MARKERS = {
@@ -81,9 +95,23 @@ def _read_env_int(name, default, lo, hi, log):
 
 
 def optimize_image(
-    data, *, max_dim=DEFAULT_MAX_DIM, jpeg_quality=DEFAULT_JPEG_QUALITY, log=None
+    data,
+    *,
+    max_dim=DEFAULT_MAX_DIM,
+    max_bytes=DEFAULT_MAX_BYTES,
+    jpeg_quality=DEFAULT_JPEG_QUALITY,
+    log=None,
 ):
     """Downscale + recompress an over-size JPEG/PNG.
+
+    Two independent triggers: pixel dimensions over `max_dim`, or encoded
+    weight over `max_bytes`. An image can be well inside the dimension budget
+    and still be far too heavy — near-lossless encoding plus EXIF/Photoshop/ICC
+    baggage — which is the case the dimension gate alone missed entirely (#55).
+
+    When only the byte trigger fires the image is re-encoded at its existing
+    dimensions: it is too heavy, not too big, and shrinking it would lose
+    detail for no reason.
 
     Returns optimized bytes, or the original bytes unchanged when no
     optimization applies, calibre is unavailable, or anything fails.
@@ -92,8 +120,12 @@ def optimize_image(
     size = _read_image_size(data)
     if size is None:
         return data
-    if max(size) <= max_dim:
+    over_dim = max(size) > max_dim
+    over_bytes = len(data) > max_bytes
+    if not over_dim and not over_bytes:
         return data
+    # Fit into the dimension box only when the dimensions are the problem.
+    target_w, target_h = (max_dim, max_dim) if over_dim else size
     is_png = data[:8] == _PNG_SIG
     try:
         from calibre.utils.img import scale_image
@@ -109,8 +141,8 @@ def optimize_image(
         # back to the original bytes for every image (#11).
         _w, _h, out = scale_image(
             data,
-            width=max_dim,
-            height=max_dim,
+            width=target_w,
+            height=target_h,
             as_png=is_png,
             compression_quality=jpeg_quality,
         )
@@ -124,6 +156,9 @@ def optimize_image(
 
 
 _MIN_MAX_DIM, _MAX_MAX_DIM = 16, 20000
+# 1 KB floor (below it every image would be re-encoded pointlessly); 1 GB
+# ceiling mirrors the guardrail style used for the decode-size cap.
+_MIN_MAX_BYTES, _MAX_MAX_BYTES = 1024, 1024 * 1024 * 1024
 
 
 def optimize_images(cover_image, images, log):
@@ -131,19 +166,28 @@ def optimize_images(cover_image, images, log):
     max_dim = _read_env_int(
         "KFXGEN_IMAGE_MAX_DIM", DEFAULT_MAX_DIM, _MIN_MAX_DIM, _MAX_MAX_DIM, log
     )
+    max_bytes = _read_env_int(
+        "KFXGEN_IMAGE_MAX_BYTES", DEFAULT_MAX_BYTES, _MIN_MAX_BYTES, _MAX_MAX_BYTES, log
+    )
     quality = _read_env_int("KFXGEN_IMAGE_QUALITY", DEFAULT_JPEG_QUALITY, 1, 100, log)
     before = after = 0
     new_images = {}
     for href, data in images.items():
         before += len(data)
-        opt = optimize_image(data, max_dim=max_dim, jpeg_quality=quality, log=log)
+        opt = optimize_image(
+            data, max_dim=max_dim, max_bytes=max_bytes, jpeg_quality=quality, log=log
+        )
         after += len(opt)
         new_images[href] = opt
     new_cover = cover_image
     if cover_image:
         before += len(cover_image)
         new_cover = optimize_image(
-            cover_image, max_dim=max_dim, jpeg_quality=quality, log=log
+            cover_image,
+            max_dim=max_dim,
+            max_bytes=max_bytes,
+            jpeg_quality=quality,
+            log=log,
         )
         after += len(new_cover)
     if before and after < before:

--- a/tests/unit/test_image_optimize.py
+++ b/tests/unit/test_image_optimize.py
@@ -179,9 +179,11 @@ def test_optimize_images_reads_env_overrides(monkeypatch):
     seen = {}
     monkeypatch.setenv("KFXGEN_IMAGE_MAX_DIM", "1600")
     monkeypatch.setenv("KFXGEN_IMAGE_QUALITY", "70")
+    monkeypatch.setenv("KFXGEN_IMAGE_MAX_BYTES", "300000")
 
-    def spy(data, *, max_dim, jpeg_quality, log):
+    def spy(data, *, max_dim, max_bytes, jpeg_quality, log):
         seen["max_dim"] = max_dim
+        seen["max_bytes"] = max_bytes
         seen["q"] = jpeg_quality
         return data
 
@@ -189,3 +191,94 @@ def test_optimize_images_reads_env_overrides(monkeypatch):
     io.optimize_images(b"COVER", {"a.jpg": b"AAAA"}, _Log())
     assert seen["max_dim"] == 1600
     assert seen["q"] == 70
+    assert seen["max_bytes"] == 300000
+
+
+# ── #55: byte-size gate ──────────────────────────────────────────────────────
+
+
+def _fake_calibre(monkeypatch, calls):
+    """Install a stub calibre.utils.img whose scale_image records its args."""
+    fake = types.ModuleType("calibre.utils.img")
+
+    def scale_image(data, width, height, as_png=False, compression_quality=90):
+        calls["args"] = (width, height, as_png, compression_quality)
+        return (width, height, b"x" * 1000)
+
+    fake.scale_image = scale_image
+    monkeypatch.setitem(sys.modules, "calibre", types.ModuleType("calibre"))
+    monkeypatch.setitem(sys.modules, "calibre.utils", types.ModuleType("calibre.utils"))
+    monkeypatch.setitem(sys.modules, "calibre.utils.img", fake)
+    return calls
+
+
+@pytest.mark.unit
+def test_heavy_image_under_max_dim_is_optimized(monkeypatch):
+    """The #55 case: modest dimensions, near-lossless encoding. 1161x1800 is
+    under the 2048 dimension gate, so before this it passed through untouched
+    no matter how many bytes it was."""
+    _fake_calibre(monkeypatch, {})
+    heavy = _jpeg(1161, 1800) + b"\x00" * 2_000_000
+    out = io.optimize_image(
+        heavy, max_dim=2048, max_bytes=1_000_000, jpeg_quality=85, log=_Log()
+    )
+    assert out != heavy, "over-size-in-bytes image was not optimized"
+    assert len(out) < len(heavy)
+
+
+@pytest.mark.unit
+def test_byte_trigger_reencodes_at_original_dimensions(monkeypatch):
+    """When only the byte gate fires, dimensions must be preserved — the image
+    is too heavy, not too big."""
+    calls = _fake_calibre(monkeypatch, {})
+    heavy = _jpeg(1161, 1800) + b"\x00" * 2_000_000
+    io.optimize_image(heavy, max_dim=2048, max_bytes=1_000_000, log=_Log())
+    assert calls["args"][:2] == (1161, 1800), (
+        f"expected re-encode at original dims, got {calls['args'][:2]}"
+    )
+
+
+@pytest.mark.unit
+def test_dimension_trigger_still_downscales_to_max_dim(monkeypatch):
+    """The existing behaviour must not regress: too-wide images still shrink."""
+    calls = _fake_calibre(monkeypatch, {})
+    big = _jpeg(4000, 3000) + b"\x00" * 2_000_000
+    io.optimize_image(big, max_dim=2048, max_bytes=1_000_000, log=_Log())
+    assert calls["args"][:2] == (2048, 2048)
+
+
+@pytest.mark.unit
+def test_light_image_under_both_gates_untouched(monkeypatch):
+    _fake_calibre(monkeypatch, {})
+    light = _jpeg(800, 600)
+    assert io.optimize_image(light, max_dim=2048, max_bytes=1_000_000) is light
+
+
+@pytest.mark.unit
+def test_byte_gate_respects_env_override(monkeypatch):
+    monkeypatch.setenv("KFXGEN_IMAGE_MAX_BYTES", "500000")
+    log = _Log()
+    assert (
+        io._read_env_int(
+            "KFXGEN_IMAGE_MAX_BYTES", io.DEFAULT_MAX_BYTES, 1, 1 << 30, log
+        )
+        == 500000
+    )
+
+
+@pytest.mark.unit
+def test_reencode_larger_than_original_is_discarded(monkeypatch):
+    """Existing guard must still hold on the byte path — never grow an image."""
+    fake = types.ModuleType("calibre.utils.img")
+    fake.scale_image = (
+        lambda data, width, height, as_png=False, compression_quality=90: (
+            width,
+            height,
+            b"y" * (len(data) + 10),
+        )
+    )
+    monkeypatch.setitem(sys.modules, "calibre", types.ModuleType("calibre"))
+    monkeypatch.setitem(sys.modules, "calibre.utils", types.ModuleType("calibre.utils"))
+    monkeypatch.setitem(sys.modules, "calibre.utils.img", fake)
+    heavy = _jpeg(1161, 1800) + b"\x00" * 2_000_000
+    assert io.optimize_image(heavy, max_dim=2048, max_bytes=1_000_000) == heavy


### PR DESCRIPTION
Fixes #55.

## What the source EPUB settled

With the EPUB in hand, two things are now proven rather than inferred:

- **kfxgen picked the right cover.** The EPUB declares `<meta name="cover" content="cover-image"/>` → the cover image file, and that is exactly what was embedded. The similarly-sized `img_6` (1168x1800 vs the cover's 1161x1800) is the title-page art, correctly kept separate. **The cover-selection hypothesis is dead.**
- **The cover is embedded byte-for-byte verbatim** — identical SHA-256 to the EPUB source. Pass-through is confirmed, not deduced from the gate arithmetic.

## The defect

```python
if max(size) <= max_dim:   # DEFAULT_MAX_DIM = 2048
    return data
```

`max(1161, 1800) = 1800 ≤ 2048`, so a 2.25 MB image is returned untouched. And since **every** image in that book is under 2048px, none of its 16 images was optimized — 7,677,756 bytes embedded verbatim.

## The fix

A second, independent trigger on encoded weight. When only the byte trigger fires, the image is re-encoded **at its existing dimensions** — it is too heavy, not too big. The existing never-return-something-larger guard still applies.

Default 1 MiB, override via `KFXGEN_IMAGE_MAX_BYTES`.

## Choosing the default from data, not taste

My first measurement was **wrong and I corrected it**: I included two files with >1 MB images as "references", then checked their provenance — both were kfxgen's own output (resource id `cover_img`; Amazon and KFX Output use `eN`/`rsrcN`). One of them, despite being named `test_calibre_output.kfx`, has a cover of *exactly* 1,048,576 bytes ending in `0000` instead of `ffd9` — a JPEG truncated at exactly 2^20. That is a February artifact; no 1 MiB constant exists in the current code, so I have not chased it, but it is worth knowing about.

Genuine references only — 212 images across three Amazon-produced KFX files:

| | |
|---|---|
| largest single image | **465,635 bytes** |
| images over 512 KB | **0** |
| median | 43,409 |

1 MiB is therefore ~2x the observed ceiling: it catches the pathological tail without recompressing merely-large images. `KFXGEN_IMAGE_MAX_BYTES=512000` tracks Amazon more tightly.

## Result on the real book

```
total images  7,677,756 -> 4,350,071 bytes  (43% smaller, no dimension changes)
cover         2,254,253 ->   490,594 bytes  (still 1161x1800)
images >1MiB          3 -> 0
```

## What this does NOT claim

That it fixes "cover does not display on Kindle". That report surfaced the defect and the sizes are conspicuous, but the causal link is **unconfirmed** — the competing explanation is the EXIF + Photoshop + ICC + Adobe header stack, which none of the working covers carry. Both are resolved by re-encoding, so the fix is identical either way, but the diagnosis is not established and the changelog says so.

A controlled A/B is built and awaiting a sideload: same plugin build, same book, differing **only** by `KFXGEN_IMAGE_MAX_BYTES` — so cover encoding is the single variable. (My first attempt at this pair was confounded — the two files came from different plugin builds — and was rebuilt.)

## Version

No version bump here, deliberately: #54 already claims 5.6.0 and bumping in both guarantees a conflict. The changelog entry is under `Unreleased` (a new heading for this repo) to be folded into whichever release lands first.

## Tests

7 new tests, written failing first, covering both triggers, dimension preservation on the byte path, env override, and the never-grow guard. One pre-existing test needed its spy signature widened for the new parameter. Full suite: 515 passed, 12 skipped. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
