### PR TITLE
fix: TOC extraction — nested lists, tail flags, hidden navs (#58, #59, #60)

### DIFF
--- a/plugin/kfxgen/converter.py
+++ b/plugin/kfxgen/converter.py
@@ -220,7 +220,13 @@ def _walk_inline(
                 )
             )
         if child.tail:
-            parts.append((child.tail, flags))
+            # The tail sits inside `elem`, so it carries `cur` — this element's
+            # accumulated flags — not the incoming `flags`. Using `flags` here
+            # dropped whatever `elem` itself contributed: text after a nested
+            # tag inside <em> lost its italic, and text between styled spans
+            # inside an <a> lost the link, leaving entries half-underlined and
+            # half-dead. (#59)
+            parts.append((child.tail, cur))
     return parts
 
 
@@ -253,6 +259,26 @@ def _dedupe_keep_order(items):
             seen.add(it)
             out.append(it)
     return out
+
+
+#: epub:type values naming navigation that is never rendered as body text.
+#: page-list is the big one: an EPUB 3 print-pagination nav holds one entry per
+#: printed page, which arrived as several hundred bare page numbers. (#60)
+_NON_RENDERED_EPUB_TYPES = {"page-list", "landmarks", "lot", "loi", "lov"}
+_EPUB_TYPE_ATTR = "{http://www.idpf.org/2007/ops}type"
+
+
+def _is_non_rendered(elem):
+    """True when `elem` heads a subtree that is markup, not reading content.
+
+    Two signals: the HTML5 `hidden` attribute (the general rule — the producer
+    said not to display this), and an `epub:type` naming a navigation kind that
+    is structural by definition, which catches producers that omit `hidden`.
+    """
+    if elem.get("hidden") is not None:
+        return True
+    raw = elem.get(_EPUB_TYPE_ATTR) or elem.get("epub:type") or ""
+    return any(part in _NON_RENDERED_EPUB_TYPES for part in raw.lower().split())
 
 
 def _attach_anchor_keys(blocks, base_href):
@@ -301,6 +327,11 @@ def extract_blocks_from_html(element, style_resolver=None, base_href=None):
         "h6",
         "blockquote",
         "li",
+        # ol/ul must count as blocks, otherwise an <li> holding a nested list
+        # looks childless and the whole sub-list is flattened into the parent's
+        # paragraph — a Part heading and all its chapters on one line. (#58)
+        "ol",
+        "ul",
         "section",
         "article",
         "figure",
@@ -312,6 +343,8 @@ def extract_blocks_from_html(element, style_resolver=None, base_href=None):
     pending_ids = []  # anchors awaiting the next leaf block (containers, standalone <a>)
 
     def _walk(elem, parent_is_block):
+        if _is_non_rendered(elem):
+            return
         is_block = elem.tag in block_tags
         has_block_child = any(child.tag in block_tags for child in elem)
 
@@ -357,8 +390,51 @@ def extract_blocks_from_html(element, style_resolver=None, base_href=None):
             return
 
         pending_ids.extend(_own_anchor_ids(elem))
+
+        # A container can hold its own inline content alongside block children —
+        # `<li>Part<ol>…</ol></li>`, `<div>lead-in<p>…</p></div>`. That inline
+        # content is real text and used to be dropped on the floor, because this
+        # branch only recursed into children. Flush each run of inline siblings
+        # as its own block, in document order. (#58)
+        inline_parts = []
+
+        def _flush_inline():
+            if not inline_parts:
+                return
+            text, spans = normalize_runs(inline_parts)
+            inline_parts.clear()
+            if not text:
+                return
+            ids = pending_ids[:]
+            pending_ids.clear()
+            blocks.append(
+                {
+                    "text": text,
+                    "spans": spans,
+                    "block_style": None,
+                    "anchor_ids": _dedupe_keep_order(ids),
+                }
+            )
+
+        if elem.text:
+            inline_parts.append((elem.text, frozenset()))
         for child in elem:
-            _walk(child, parent_is_block=is_block)
+            if child.tag in block_tags or _local_tag(child.tag) == "img":
+                _flush_inline()
+                _walk(child, parent_is_block=is_block)
+            elif not _is_non_rendered(child):
+                inline_parts.extend(
+                    _walk_inline(
+                        child,
+                        frozenset(),
+                        style_resolver,
+                        is_root=False,
+                        base_href=base_href,
+                    )
+                )
+            if child.tail:
+                inline_parts.append((child.tail, frozenset()))
+        _flush_inline()
 
     for child in body:
         _walk(child, parent_is_block=False)

--- a/tests/unit/test_converter.py
+++ b/tests/unit/test_converter.py
@@ -512,7 +512,7 @@ from kfxgen.inline_style import FLAG_ITALIC as I  # noqa: E402, N816
 
 def _doc(body_inner):
     return etree.fromstring(
-        f'<html xmlns="http://www.w3.org/1999/xhtml"><body>{body_inner}</body></html>'.encode()
+        f'<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops"><body>{body_inner}</body></html>'.encode()
     )
 
 
@@ -1399,3 +1399,96 @@ def test_anchor_keys_absent_base_href_falls_back_to_bare_ids():
     blocks = _conv.extract_blocks_from_html(_doc('<p id="note1">A note</p>'))
     assert blocks[0]["anchor_ids"] == ["note1"]
     assert blocks[0]["anchor_keys"] == []
+
+
+# ── #58/#59/#60: TOC extraction defects ──────────────────────────────────────
+
+
+@pytest.mark.unit
+def test_nested_list_inside_li_is_not_flattened():
+    """#58: <li> whose child is a nested <ol> must not be treated as a leaf.
+    A Part heading and its chapters collapsed into one run-on paragraph."""
+    blocks = _conv.extract_blocks_from_html(
+        _doc("<ol><li>Part<ol><li>Ch1</li><li>Ch2</li></ol></li></ol>")
+    )
+    assert [b["text"] for b in blocks] == ["Part", "Ch1", "Ch2"]
+
+
+@pytest.mark.unit
+def test_nested_ul_inside_li_is_not_flattened():
+    blocks = _conv.extract_blocks_from_html(
+        _doc("<ul><li>Top<ul><li>Sub</li></ul></li></ul>")
+    )
+    assert [b["text"] for b in blocks] == ["Top", "Sub"]
+
+
+@pytest.mark.unit
+def test_tail_after_nested_tag_keeps_enclosing_italic():
+    """#59: ' gamma' sits inside <em> and must stay italic. It was getting the
+    *incoming* flags instead of the enclosing element's."""
+    blocks = _conv.extract_blocks_from_html(
+        _doc("<p><em>alpha <b>beta</b> gamma</em></p>")
+    )
+    text = blocks[0]["text"]
+    assert text == "alpha beta gamma"
+    covered = {}
+    for s, length, flags in blocks[0]["spans"]:
+        for i in range(s, s + length):
+            covered[i] = flags
+    tail_start = text.index("gamma")
+    assert all(
+        I in covered.get(i, frozenset()) for i in range(tail_start, len(text))
+    ), "tail text inside <em> lost its italic"
+
+
+@pytest.mark.unit
+def test_tail_after_nested_tag_keeps_enclosing_link():
+    """#59, link form: the real TOC shape — <a> wrapping styled spans with bare
+    text between them. Every character of the anchor must carry the link."""
+    doc = _doc(
+        '<p><a href="c.xhtml#t"><span>PART I</span> T<span>he</span> End</a></p>'
+    )
+    blocks = _conv.extract_blocks_from_html(doc, base_href="toc.xhtml")
+    text = blocks[0]["text"]
+    covered = {}
+    for s, length, flags in blocks[0]["spans"]:
+        for i in range(s, s + length):
+            covered[i] = flags
+    assert all(
+        link_target(covered.get(i, frozenset())) == "c.xhtml#t"
+        for i in range(len(text))
+    ), (
+        f"anchor text only partly linked: "
+        f"{[(i, text[i], link_target(covered.get(i, frozenset()))) for i in range(len(text))]}"
+    )
+
+
+@pytest.mark.unit
+def test_hidden_attribute_subtree_is_skipped():
+    """#60: hidden='hidden' content is not rendered content."""
+    blocks = _conv.extract_blocks_from_html(
+        _doc('<p>visible</p><nav hidden="hidden"><p>SHOULD NOT APPEAR</p></nav>')
+    )
+    assert [b["text"] for b in blocks] == ["visible"]
+
+
+@pytest.mark.unit
+def test_page_list_nav_is_skipped_even_without_hidden():
+    """#60: page-list/landmarks are navigation, never body text — some
+    producers omit the hidden attribute."""
+    blocks = _conv.extract_blocks_from_html(
+        _doc(
+            "<p>real</p>"
+            '<nav epub:type="page-list"><ol><li><a href="a.xhtml#p1">1</a></li></ol></nav>'
+            '<nav epub:type="landmarks"><ol><li><a href="a.xhtml">Begin</a></li></ol></nav>'
+        )
+    )
+    assert [b["text"] for b in blocks] == ["real"]
+
+
+@pytest.mark.unit
+def test_hidden_does_not_swallow_normal_content():
+    blocks = _conv.extract_blocks_from_html(
+        _doc('<p hidden="hidden">gone</p><p>kept</p>')
+    )
+    assert [b["text"] for b in blocks] == ["kept"]


### PR DESCRIPTION
Fixes #58, #59, #60. Stacked on #54 (they touch the same `_walk_inline`).

Device report: the contents page showed a Part and all its chapters as one run-on paragraph with only the chapter number underlined, plus a stray "Page List" of `VII, viii, 1, 2, 3…` afterwards.

## None of this is a regression

I checked before assuming. Extracting from a **pre-5.6.0** `.kfx` of the same book gives byte-for-byte the same damage — 374 page-number blocks and the identical merged `PART I …` paragraph. The link work in #54 did not cause any of it; it made it visible, by rendering the damage as underlined links instead of anonymous grey text.

## #58 — nested lists flattened

`block_tags` had `li` but not `ol`/`ul`, so `<li>Part<ol><li>Ch1</li></ol></li>` looked childless and the whole sub-list was flattened.

Fixing it exposed the other half of the same bug: a container's own inline text was **dropped** when it also had block children, because that branch only recursed. Inline runs are now flushed as their own blocks in document order — so `<div>lead-in<p>…</p></div>` stops losing "lead-in" too.

## #59 — tail text lost its enclosing flags

```python
parts.append((child.tail, flags))   # incoming flags, not this element's
```

The tail is *inside* `elem`, so it must carry `cur`. This has been silently mangling **emphasis** since inline emphasis landed — in `<em>alpha <b>beta</b> gamma</em>`, ` gamma` was not italic. Nobody noticed because a missing italic is easy to overlook; a half-underlined link is not. That is the more valuable half of this PR.

## #60 — hidden navs rendered

`hidden="hidden"` was ignored, so EPUB 3 `page-list` and `landmarks` navs became body text — one block per printed page.

Skips on the HTML5 `hidden` attribute (general rule) and on `epub:type` naming a structural nav (catches producers that omit `hidden`).

## Result on the real book

| | before | after |
|---|---|---|
| blocks from `toc.xhtml` | 328 | **39** |
| page-list junk blocks | 310 | **0** |
| `PART I` entry | run-on paragraph, digit linked | own block, **single span over all 38 chars** |

## Tests

7 new, written failing first, each pinned to a minimal repro. Full suite 567 passed, 12 skipped. Ruff clean. Golden corpus unchanged.

**Not yet device-verified** — needs a sideload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)