### PR TITLE
fix: stop losing anchors for back-matter and whole-file link targets (#62)

### DIFF
--- a/plugin/kfxgen/converter.py
+++ b/plugin/kfxgen/converter.py
@@ -292,6 +292,13 @@ def _attach_anchor_keys(blocks, base_href):
             if normalized
             else []
         )
+    # A TOC entry may link to a whole file with no fragment
+    # (`<a href="about.xhtml">About the Author</a>`). Give the document's first
+    # block a bare-filename key so such links have something to resolve to —
+    # otherwise a file that declares no ids anywhere is unreachable and the
+    # link is silently dropped. (#62)
+    if normalized and blocks:
+        blocks[0]["anchor_keys"] = [normalized] + blocks[0]["anchor_keys"]
     return blocks
 
 

--- a/plugin/kfxgen/native_generator.py
+++ b/plugin/kfxgen/native_generator.py
@@ -40,6 +40,17 @@ SUPERSCRIPT_SHIFT = ("35", "$314")  # +35% of font size
 SUBSCRIPT_SHIFT = ("-20", "$314")  # -20% of font size
 
 
+def _dedupe_keys(keys):
+    """Order-preserving dedupe for anchor-key lists."""
+    seen = set()
+    out = []
+    for k in keys:
+        if k not in seen:
+            seen.add(k)
+            out.append(k)
+    return out
+
+
 def _safe_write_bytes(path, data):
     """Write `data` to `path` with symlink and traversal defenses (#45).
 
@@ -2471,6 +2482,10 @@ class NativeKFXGenerator:
 
         for ch_idx, chapter in enumerate(chapters):
             start_idx = len(all_chunks)
+            # Anchor ids belonging to blocks this chapter drops (a heading that
+            # duplicates the chapter title). Re-attached to the chapter's first
+            # chunk below so links to those ids still resolve. (#62)
+            carried_anchor_keys = []
             title = chapter["title"]
             toc_links = chapter.get("toc_links")
 
@@ -2544,6 +2559,15 @@ class NativeKFXGenerator:
                                         "spans": rebased_spans,
                                     }
                                 else:
+                                    # The block is gone, but its ids are what
+                                    # the TOC links to — a back-matter file
+                                    # opening with a heading equal to its
+                                    # chapter title is the common shape. Carry
+                                    # them onto the chapter's first chunk so
+                                    # the link still lands here. (#62)
+                                    carried_anchor_keys.extend(
+                                        first.get("anchor_keys") or []
+                                    )
                                     iter_blocks = iter_blocks[1:]
                         para_iter = iter_blocks
                     else:
@@ -2560,6 +2584,11 @@ class NativeKFXGenerator:
                         block_anchor_keys = block.get("anchor_keys") or []
                         for chunk in _emit_text_chunks(para):
                             if chunk["type"] == "image":
+                                # Figure ids live on image blocks; without this
+                                # a link to a figure resolved to nothing. (#62)
+                                if block_anchor_keys:
+                                    chunk["anchor_keys"] = block_anchor_keys
+                                    block_anchor_keys = []
                                 all_chunks.append(chunk)
                             else:
                                 _append_text_with_spans(
@@ -2584,6 +2613,12 @@ class NativeKFXGenerator:
             # chapter silently pointed its TOC entry at the next chapter.
             if len(all_chunks) == start_idx:
                 all_chunks.append({"type": "text", "text": " "})
+
+            if carried_anchor_keys:
+                first_chunk = all_chunks[start_idx]
+                first_chunk["anchor_keys"] = _dedupe_keys(
+                    (first_chunk.get("anchor_keys") or []) + carried_anchor_keys
+                )
 
             chapter_chunk_ranges.append((start_idx, len(all_chunks)))
 

--- a/tests/unit/test_converter.py
+++ b/tests/unit/test_converter.py
@@ -1391,7 +1391,10 @@ def test_blocks_carry_file_qualified_anchor_keys():
     blocks = _conv.extract_blocks_from_html(
         _doc('<p id="note1">A note</p>'), base_href="endnotes.xhtml"
     )
-    assert blocks[0]["anchor_keys"] == ["endnotes.xhtml#note1"]
+    # The bare filename is prepended to the first block so whole-file links
+    # resolve (#62); the id-qualified key is what matters here.
+    assert "endnotes.xhtml#note1" in blocks[0]["anchor_keys"]
+    assert blocks[0]["anchor_keys"] == ["endnotes.xhtml", "endnotes.xhtml#note1"]
 
 
 @pytest.mark.unit
@@ -1492,3 +1495,20 @@ def test_hidden_does_not_swallow_normal_content():
         _doc('<p hidden="hidden">gone</p><p>kept</p>')
     )
     assert [b["text"] for b in blocks] == ["kept"]
+
+
+@pytest.mark.unit
+def test_first_block_carries_bare_filename_anchor_key():
+    """#62: a TOC entry may link to a whole file with no fragment. If that file
+    declares no ids anywhere, nothing anchors it and the link is dropped."""
+    blocks = _conv.extract_blocks_from_html(
+        _doc("<p>About the author.</p><p>More.</p>"), base_href="038_BM_006.xhtml"
+    )
+    assert "038_BM_006.xhtml" in blocks[0]["anchor_keys"]
+    assert "038_BM_006.xhtml" not in blocks[1]["anchor_keys"]
+
+
+@pytest.mark.unit
+def test_bare_filename_key_absent_without_base_href():
+    blocks = _conv.extract_blocks_from_html(_doc("<p>x</p>"))
+    assert blocks[0]["anchor_keys"] == []

--- a/tests/unit/test_native_generator.py
+++ b/tests/unit/test_native_generator.py
@@ -1848,3 +1848,107 @@ def test_unreferenced_anchor_ids_emit_no_anchor_fragments(tmp_path):
         title="T", author="A", chapters=chapters, output_path=str(tmp_path / "o.kfx")
     )
     assert _anchor_index(gen) == {}
+
+
+# ── #62: anchors on elided/image blocks must survive ─────────────────────────
+
+
+@pytest.mark.unit
+def test_anchor_on_title_duplicate_block_survives_elision(tmp_path):
+    """A back-matter file often opens with a heading equal to the chapter title.
+    That block is elided as redundant — but it carries the id the TOC links to,
+    so dropping its anchor_keys silently killed the link. (#62)"""
+    from kfxgen.inline_style import make_link_flag
+
+    gen = NativeKFXGenerator()
+    chapters = [
+        {
+            "title": "Contents",
+            "text": "Notes",
+            "blocks": [
+                {
+                    "text": "Notes",
+                    "spans": [
+                        (0, 5, frozenset({make_link_flag("notes.xhtml#toc_55")}))
+                    ],
+                    "anchor_keys": [],
+                }
+            ],
+        },
+        {
+            "title": "Notes",
+            "text": "NOTES\n\nFirst note.",
+            "blocks": [
+                {"text": "NOTES", "spans": [], "anchor_keys": ["notes.xhtml#toc_55"]},
+                {"text": "First note.", "spans": [], "anchor_keys": []},
+            ],
+        },
+    ]
+    gen.generate_full_book(
+        title="T", author="A", chapters=chapters, output_path=str(tmp_path / "o.kfx")
+    )
+    anchors = {
+        str((f.value.value if hasattr(f.value, "value") else f.value)[IS_180()])
+        for f in gen.fragments
+        if str(f.ftype) == "$266"
+    }
+    targets = _collect_link_targets(gen)
+    assert targets, "link to an elided-heading anchor was dropped entirely"
+    assert set(targets) <= anchors
+
+
+@pytest.mark.unit
+def test_anchor_on_image_block_survives(tmp_path):
+    """Figure ids live on image blocks; those chunks were appended without
+    anchor_keys, so links to figures resolved to nothing. (#62)"""
+    from kfxgen.inline_style import make_link_flag
+
+    gen = NativeKFXGenerator()
+    chapters = [
+        {
+            "title": "Ch",
+            "text": "see figure",
+            "blocks": [
+                {
+                    "text": "see figure",
+                    "spans": [(0, 3, frozenset({make_link_flag("c.xhtml#fig3")}))],
+                    "anchor_keys": [],
+                },
+                {
+                    "text": "\x00IMG\x01img.jpg\x01alt\x00",
+                    "spans": [],
+                    "anchor_keys": ["c.xhtml#fig3"],
+                },
+            ],
+        }
+    ]
+    gen.generate_full_book(
+        title="T",
+        author="A",
+        chapters=chapters,
+        images={"img.jpg": b"\xff\xd8\xff\xe0" + b"\x00" * 100},
+        output_path=str(tmp_path / "o.kfx"),
+    )
+    targets = _collect_link_targets(gen)
+    assert targets, "link to a figure anchor was dropped entirely"
+
+
+def IS_180():
+    from kfxgen.kfxlib_minimal.ion import IS
+
+    return IS("$180")
+
+
+def _collect_link_targets(gen):
+    from kfxgen.kfxlib_minimal.ion import IS
+
+    out = []
+    for f in gen.fragments:
+        if str(f.ftype) != "$259":
+            continue
+        v = f.value.value if hasattr(f.value, "value") else f.value
+        for e in v.get(IS("$146")) or []:
+            for sp in e.get(IS("$142")) or []:
+                if IS("$179") in sp:
+                    out.append(str(sp[IS("$179")]))
+    return out


### PR DESCRIPTION
Fixes #62. Stacked on #61.

Six TOC entries were inert on device. Extraction was correct in all six — the anchors were lost between the chapter list and the chunk list. **20 anchor keys** vanished this way on the affected book.

| path | cause |
|---|---|
| elided title-duplicate block | back-matter opens with a heading equal to its chapter title; the block is dropped as redundant, taking the TOC target id with it |
| image blocks | appended without `anchor_keys`, so figure ids (`#fig3`) anchored nothing |
| whole-file targets | `<a href="about.xhtml">` only resolved if that file declared some id; files declaring none were unreachable |

## Result on the real book

All six now link with full character coverage:

```
LINK cov= 9/9   AFTERWORD
LINK cov=13/13  Discover More
LINK cov=12/12  Bibliography
LINK cov=16/16  About the Author
LINK cov=19/19  Also by <author>
LINK cov= 5/5   Notes
```

## Diagnosis note

I tested the elision hypothesis early and **wrongly ruled it out** — my probe called `extract_chapters_from_oeb` without `metadata=`, which yields generic `Section 35` titles that never match the heading. With metadata the real titles match and the elision fires. I had already told the user it was not the cause. Recording it because the wrong conclusion looked well-supported, and only instrumenting the real generator settled it.

## Generality

Smoke-tested across four other EPUBs (English trade non-fiction, Russian, Korean, Japanese): all convert, **zero dangling links**, no nav junk. 571 tests pass, ruff clean, golden corpus unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
