### PR TITLE
fix: chapter opener repeated when split across blocks (#64) + public-domain corpus gate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,3 +169,35 @@ project root. If you change anything that touches `$259`, `$260`, `$264`,
 before merging. Tier-1 invariant tests (issue 43)
 encode many of these rules, but not all of them — when in doubt, test on
 device.
+
+## Public-domain corpus sweep
+
+`tests/integration/test_public_corpus.py` runs real books through the whole
+pipeline and checks invariants that the unit suite cannot. It exists because
+unit tests and the synthetic golden corpus both passed while kfxgen was silently
+discarding 44% of one book's body text, and while every internal link it emitted
+resolved against nothing. Each assertion maps to a bug that shipped.
+
+The corpus is not committed — point the test at a local directory of `.epub`
+files (the Gutenberg top-90 set is what it was built against):
+
+```bash
+export KFXGEN_CORPUS_DIR=/path/to/corpus
+pytest tests/integration/test_public_corpus.py -m slow
+```
+
+Without `KFXGEN_CORPUS_DIR` the tests skip, so a normal run is unaffected.
+
+Invariants alone will not catch text quietly going missing. For that, record a
+baseline before a change and diff against it after:
+
+```bash
+KFXGEN_CORPUS_WRITE_BASELINE=1 KFXGEN_CORPUS_BASELINE=corpus-baseline.json \
+  pytest tests/integration/test_public_corpus.py -m slow -k baseline   # record
+
+KFXGEN_CORPUS_BASELINE=corpus-baseline.json \
+  pytest tests/integration/test_public_corpus.py -m slow -k baseline   # compare
+```
+
+The baseline is keyed by filename and is a local artifact — keep it out of the
+repo, alongside the corpus itself.

--- a/plugin/kfxgen/native_generator.py
+++ b/plugin/kfxgen/native_generator.py
@@ -40,6 +40,42 @@ SUPERSCRIPT_SHIFT = ("35", "$314")  # +35% of font size
 SUBSCRIPT_SHIFT = ("-20", "$314")  # -20% of font size
 
 
+#: How many leading blocks may be consumed as a split chapter opener. Two
+#: covers the common numeral+title shape; three allows a subtitle line. Beyond
+#: that the risk of eating real body text outweighs the tidier heading.
+_MAX_SPLIT_TITLE_BLOCKS = 3
+
+
+def _normalize_title(text):
+    """Case-fold and drop punctuation/whitespace for title comparison.
+
+    A split opener writes "3" and "Chapter Title Here" where the TOC says
+    "3. Chapter Title Here" — the separator lives only in the TOC form, so the
+    comparison has to ignore it.
+    """
+    return "".join(ch for ch in text.lower() if ch.isalnum())
+
+
+def _consume_split_title(blocks, title):
+    """Number of leading blocks that together reconstruct `title` exactly.
+
+    Returns 0 when they do not, so ordinary body text is never eaten. The match
+    must be complete: a prefix is not enough, or a chapter whose first paragraph
+    happens to open with the title's words would lose it. (#64)
+    """
+    target = _normalize_title(title)
+    if not target:
+        return 0
+    acc = ""
+    for i, blk in enumerate(blocks[:_MAX_SPLIT_TITLE_BLOCKS]):
+        acc += _normalize_title(blk.get("text", ""))
+        if acc == target:
+            return i + 1
+        if not target.startswith(acc):
+            return 0
+    return 0
+
+
 def _dedupe_keys(keys):
     """Order-preserving dedupe for anchor-key lists."""
     seen = set()
@@ -2569,6 +2605,20 @@ class NativeKFXGenerator:
                                         first.get("anchor_keys") or []
                                     )
                                     iter_blocks = iter_blocks[1:]
+                            else:
+                                # Publishers routinely split the opener across
+                                # elements — the numeral in one, the title in
+                                # the next. The single-block test above misses
+                                # that, so the synthesized heading landed on top
+                                # of the book's own opener and the chapter name
+                                # rendered twice. (#64)
+                                eaten = _consume_split_title(iter_blocks, title)
+                                if eaten:
+                                    for blk in iter_blocks[:eaten]:
+                                        carried_anchor_keys.extend(
+                                            blk.get("anchor_keys") or []
+                                        )
+                                    iter_blocks = iter_blocks[eaten:]
                         para_iter = iter_blocks
                     else:
                         para_iter = [

--- a/tests/integration/test_public_corpus.py
+++ b/tests/integration/test_public_corpus.py
@@ -1,0 +1,179 @@
+"""Structural regression sweep over a corpus of public-domain EPUBs.
+
+Opt-in: set ``KFXGEN_CORPUS_DIR`` to a directory of ``.epub`` files (the
+Gutenberg top-90 set is what this was built against). Skips cleanly when the
+variable is unset, so it never blocks a normal test run or CI without a corpus.
+
+Why this exists: the unit suite and the synthetic golden corpus both passed
+while kfxgen was silently discarding 44% of one book's body text (#58) and
+while *every* internal link it had ever emitted resolved against nothing (#51).
+Neither shows up without running real books and checking invariants across
+them. Each assertion here corresponds to a bug that actually shipped.
+
+Two modes:
+
+* invariants only (default) — properties that must hold for any book
+* baseline diff (``KFXGEN_CORPUS_BASELINE=/path/to.json``) — per-book metrics
+  compared against a recorded run, which is what catches silent text loss.
+  Regenerate with ``KFXGEN_CORPUS_WRITE_BASELINE=1``. The baseline is keyed by
+  filename and is a local artifact; it is not committed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+
+import pytest
+
+from kfxgen import converter as conv
+from kfxgen.kfxlib_minimal.ion import IS
+from kfxgen.native_generator import NativeKFXGenerator
+from tests._kfx_introspect import by_type, load_fragments, val
+from tests.fixtures.oeb_shim import EpubAsOeb
+
+CORPUS_ENV = "KFXGEN_CORPUS_DIR"
+BASELINE_ENV = "KFXGEN_CORPUS_BASELINE"
+WRITE_ENV = "KFXGEN_CORPUS_WRITE_BASELINE"
+
+#: Text that means a non-rendered navigation document leaked into the body (#60).
+NAV_MARKERS = frozenset(
+    {"Page List", "Navigation", "Begin Reading", "Table of Contents"}
+)
+
+#: A book may legitimately shrink slightly (deduplicated headings, #64) or grow
+#: (recovered container text, #58). Only flag movement beyond this.
+TEXT_DRIFT_TOLERANCE = 0.02
+
+
+def _corpus_files():
+    root = os.environ.get(CORPUS_ENV)
+    if not root:
+        return []
+    return sorted(Path(root).glob("*.epub"))
+
+
+def _silent_log():
+    log = logging.getLogger("corpus")
+    log.addHandler(logging.NullHandler())
+    log.setLevel(logging.CRITICAL)
+    for name in ("warn", "info", "error", "debug"):
+        if not hasattr(log, name):
+            setattr(log, name, lambda *a, **k: None)
+    log.warn = log.warning
+    return log
+
+
+def _convert(epub_path, out_path):
+    log = _silent_log()
+    oeb = EpubAsOeb(str(epub_path))
+    metadata = conv.extract_metadata(oeb, log)
+    chapters = conv.extract_chapters_from_oeb(oeb, log, metadata=metadata)
+    gen = NativeKFXGenerator()
+    gen.generate_full_book(
+        title=metadata["title"],
+        author=metadata["author"],
+        chapters=chapters,
+        output_path=str(out_path),
+    )
+    return out_path
+
+
+def _metrics(kfx_path):
+    frags = load_fragments(kfx_path)
+    texts = [
+        x
+        for f in by_type(frags, "$145")
+        for x in (val(f).get(IS("$146")) or [])
+        if isinstance(x, str)
+    ]
+    anchors = set()
+    unnamed = 0
+    for f in by_type(frags, "$266"):
+        v = val(f)
+        name = v.get(IS("$180"))
+        if name is None:
+            unnamed += 1
+        else:
+            anchors.add(str(name))
+    targets = []
+    for f in by_type(frags, "$259"):
+        for entry in val(f).get(IS("$146")) or []:
+            for span in entry.get(IS("$142")) or []:
+                if IS("$179") in span:
+                    targets.append(str(span[IS("$179")]))
+    return {
+        "chars": sum(len(t) for t in texts),
+        "blocks": len(texts),
+        "anchors": len(anchors),
+        "anchors_without_180": unnamed,
+        "links": len(targets),
+        "dangling": len(set(targets) - anchors),
+        "nav_junk": sum(1 for t in texts if t.strip() in NAV_MARKERS),
+    }
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.skipif(not _corpus_files(), reason=f"{CORPUS_ENV} not set or empty")
+@pytest.mark.parametrize("epub", _corpus_files(), ids=lambda p: p.stem[:40])
+def test_corpus_book_invariants(epub, tmp_path):
+    """Properties that must hold for every book, each tied to a shipped bug."""
+    m = _metrics(_convert(epub, tmp_path / "out.kfx"))
+
+    assert m["chars"] > 0, "book produced no text at all"
+    # #51: an anchor with no $180 has no name for $179 to resolve against, so
+    # every link pointing at it silently dies.
+    assert m["anchors_without_180"] == 0, (
+        f"{m['anchors_without_180']} $266 anchors are missing $180"
+    )
+    # #53/#62: a link must never reference an anchor that does not exist.
+    assert m["dangling"] == 0, f"{m['dangling']} link targets resolve to nothing"
+    # #60: hidden page-list/landmarks navs are markup, never reading content.
+    assert m["nav_junk"] == 0, f"{m['nav_junk']} navigation blocks leaked into the body"
+
+
+@pytest.mark.integration
+@pytest.mark.slow
+@pytest.mark.skipif(not _corpus_files(), reason=f"{CORPUS_ENV} not set or empty")
+def test_corpus_metrics_match_baseline(tmp_path):
+    """Diff per-book metrics against a recorded run.
+
+    This is the check that catches *silent* damage — text quietly disappearing
+    or links quietly vanishing while every invariant above still holds.
+    """
+    baseline_path = os.environ.get(BASELINE_ENV)
+    writing = os.environ.get(WRITE_ENV)
+    if not baseline_path and not writing:
+        pytest.skip(f"set {BASELINE_ENV} to compare, or {WRITE_ENV}=1 to record")
+
+    current = {}
+    for epub in _corpus_files():
+        current[epub.name] = _metrics(_convert(epub, tmp_path / f"{epub.stem}.kfx"))
+
+    if writing:
+        target = Path(baseline_path or (Path(os.environ[CORPUS_ENV]) / "baseline.json"))
+        target.write_text(json.dumps(current, indent=2, sort_keys=True))
+        pytest.skip(f"baseline written to {target} ({len(current)} books)")
+
+    baseline = json.loads(Path(baseline_path).read_text())
+    problems = []
+    for name, want in baseline.items():
+        got = current.get(name)
+        if got is None:
+            problems.append(f"{name}: missing from this run")
+            continue
+        if want["chars"] and abs(got["chars"] - want["chars"]) / want["chars"] > (
+            TEXT_DRIFT_TOLERANCE
+        ):
+            problems.append(
+                f"{name}: text {want['chars']:,} -> {got['chars']:,} "
+                f"({100 * (got['chars'] - want['chars']) / want['chars']:+.1f}%)"
+            )
+        if got["links"] < want["links"]:
+            problems.append(f"{name}: links {want['links']} -> {got['links']}")
+        if got["dangling"] > want["dangling"]:
+            problems.append(f"{name}: dangling {want['dangling']} -> {got['dangling']}")
+    assert not problems, "corpus drift:\n  " + "\n  ".join(problems[:20])

--- a/tests/unit/test_native_generator.py
+++ b/tests/unit/test_native_generator.py
@@ -1952,3 +1952,109 @@ def _collect_link_targets(gen):
                 if IS("$179") in sp:
                     out.append(str(sp[IS("$179")]))
     return out
+
+
+# ── #64: chapter opener split across blocks ──────────────────────────────────
+
+
+def _first_texts(gen, storyline):
+    from kfxgen.kfxlib_minimal.ion import IS
+
+    txt = {}
+    for f in gen.fragments:
+        if str(f.ftype) == "$145":
+            v = f.value.value if hasattr(f.value, "value") else f.value
+            txt[str(f.fid)] = [
+                x for x in (v.get(IS("$146")) or []) if isinstance(x, str)
+            ]
+    for f in gen.fragments:
+        if str(f.ftype) != "$259" or str(f.fid) != storyline:
+            continue
+        v = f.value.value if hasattr(f.value, "value") else f.value
+        out = []
+        for e in v.get(IS("$146")) or []:
+            if IS("$145") not in e:
+                continue
+            ref = e[IS("$145")]
+            key = IS("$4") if IS("$4") in ref else IS("name")
+            n = str(ref[key])
+            i = ref[IS("$403")]
+            out.append(txt[n][i] if i < len(txt[n]) else "")
+        return out
+    return []
+
+
+@pytest.mark.unit
+def test_split_number_and_title_not_repeated_after_heading(tmp_path):
+    """#64: publishers often put the numeral and the title in separate elements.
+    The single-block strip missed that, so the synthesized heading was added on
+    top of the book's own opener and the chapter name appeared twice."""
+    gen = NativeKFXGenerator()
+    chapters = [
+        {
+            "title": "3. Chapter Title Here",
+            "text": "3\n\nChapter Title Here\n\nBody text follows.",
+            "blocks": [
+                {"text": "3", "spans": [], "anchor_keys": []},
+                {"text": "Chapter Title Here", "spans": [], "anchor_keys": []},
+                {"text": "Body text follows.", "spans": [], "anchor_keys": []},
+            ],
+        }
+    ]
+    gen.generate_full_book(
+        title="T", author="A", chapters=chapters, output_path=str(tmp_path / "o.kfx")
+    )
+    texts = _first_texts(gen, "l0")
+    assert texts[0] == "3. Chapter Title Here", "heading missing"
+    assert "Chapter Title Here" not in texts[1:], (
+        f"chapter title repeated in body: {texts}"
+    )
+    assert "Body text follows." in texts, "body text was eaten"
+
+
+@pytest.mark.unit
+def test_single_block_title_strip_still_works(tmp_path):
+    gen = NativeKFXGenerator()
+    chapters = [
+        {
+            "title": "Chapter One",
+            "text": "Chapter One\n\nBody.",
+            "blocks": [
+                {"text": "Chapter One", "spans": [], "anchor_keys": []},
+                {"text": "Body.", "spans": [], "anchor_keys": []},
+            ],
+        }
+    ]
+    gen.generate_full_book(
+        title="T", author="A", chapters=chapters, output_path=str(tmp_path / "o.kfx")
+    )
+    texts = _first_texts(gen, "l0")
+    assert texts.count("Chapter One") == 1, texts
+
+
+@pytest.mark.unit
+def test_body_text_matching_title_words_is_not_eaten(tmp_path):
+    """Guard against over-eager consumption: leading blocks must reconstruct the
+    title exactly, not merely start with the same words."""
+    gen = NativeKFXGenerator()
+    chapters = [
+        {
+            "title": "5. War",
+            "text": "5\n\nWar and its causes were debated.",
+            "blocks": [
+                {"text": "5", "spans": [], "anchor_keys": []},
+                {
+                    "text": "War and its causes were debated.",
+                    "spans": [],
+                    "anchor_keys": [],
+                },
+            ],
+        }
+    ]
+    gen.generate_full_book(
+        title="T", author="A", chapters=chapters, output_path=str(tmp_path / "o.kfx")
+    )
+    texts = _first_texts(gen, "l0")
+    assert "War and its causes were debated." in texts, (
+        f"body paragraph was wrongly consumed as part of the title: {texts}"
+    )


### PR DESCRIPTION
Fixes #64, and adds the regression gate you asked for.

## #64 — chapter name rendered twice

kfxgen synthesizes a heading from the TOC title, then strips that title from the body **only when the first block starts with it**. Publishers routinely split the opener across elements — numeral in one, title in the next — so the strip never fired and the heading landed on top of the book's own opener:

```
[heading] "3. Chapter Title Here"   <- synthesized
[body]    "3"                       <- the book's own numeral
[body]    "Chapter Title Here"      <- the book's own title
```

Now consumes the leading blocks that together reconstruct the title, compared on a normalized form (case-folded, punctuation dropped) so `3` + `Chapter Title Here` matches `3. Chapter Title Here`. Bounded to 3 blocks and requires a **complete** reconstruction, not a prefix — otherwise a chapter whose first paragraph happens to open with the title's words would lose it. There is a test for exactly that.

**Not a 5.6.0 regression.** 15 affected chapters in both 5.5.0 and 5.6.0, verified by converting the same EPUB through both builds in isolated Calibre configs. After the fix: 15 → 0, total text down 479 characters — the duplicates and nothing else.

## Public-domain corpus gate

`tests/integration/test_public_corpus.py`. Opt-in via `KFXGEN_CORPUS_DIR`; skips cleanly when unset so normal runs and CI are unaffected.

**Invariant mode** — properties that must hold for any book, each tied to a bug that shipped:

- every `$266` carries `$180` (#51 — without it every link resolves to nothing)
- no dangling `$179` (#53, #62)
- no hidden-nav text in the body (#60)
- non-empty output

**Baseline mode** — record per-book metrics before a change, diff after. This is the one that catches *silent* damage: text or links quietly vanishing while every invariant still holds. That is precisely the shape of #58, where 44% of one book's body text disappeared with nothing looking malformed.

The baseline is a local artifact keyed by filename, deliberately not committed — it belongs next to the corpus, which is also not in the repo.

I verified the gate **fails**, not just that it passes: feeding it a drifted baseline produces

```
corpus drift:
  <book>.epub: text 1,734,162 -> 1,156,108 (-33.3%)
  <book>.epub: links 2822 -> 2322
```

Also ran the invariant mode against six real Gutenberg books — all pass.

## Why this was needed

The unit suite (580 tests) and the synthetic golden corpus both passed while kfxgen was discarding 44% of a book's text and emitting exclusively dead links. Neither surfaces without real books plus cross-book invariants. Documented in CONTRIBUTING.md.

580 tests pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)