### PR TITLE
fix: directory-aware anchor keys, env-tunable typography, scheduled corpus (#68, #69, #70)

### DIFF
--- a/.github/workflows/corpus.yml
+++ b/.github/workflows/corpus.yml
@@ -1,0 +1,76 @@
+name: Corpus Sweep
+
+# Runs the public-domain corpus invariants on a schedule so they gate
+# something rather than waiting to be remembered (#70).
+#
+# The corpus is not committed — it is fetched at run time from Project
+# Gutenberg, which serves these EPUBs freely. Only the invariant mode runs
+# here: baseline diffing needs a recorded JSON from a prior run, which is
+# inherently local and stays a manual pre-release step.
+#
+# Why this exists: the unit suite and the synthetic golden corpus both passed
+# while kfxgen was discarding 44% of one book's body text and emitting
+# exclusively dead links. Neither surfaces without real books.
+
+on:
+  schedule:
+    # Weekly, Monday 06:00 UTC. Drift here is slow-moving; daily would be noise.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+    inputs:
+      book_count:
+        description: "How many Gutenberg books to fetch"
+        required: false
+        default: "20"
+
+permissions:
+  contents: read
+
+jobs:
+  corpus:
+    name: Public-domain corpus invariants
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      # Gutenberg's top-100 ids. Fetching by id keeps this independent of any
+      # local corpus and of book titles, which must not appear in this repo.
+      - name: Fetch corpus
+        run: |
+          mkdir -p corpus
+          COUNT="${{ github.event.inputs.book_count || '20' }}"
+          IDS="1342 84 11 1661 2701 98 1952 174 345 1080 5200 43 76 2542 4300 1400 16 25344 2554 74 1260 30254 6130 158 45"
+          n=0
+          for id in $IDS; do
+            [ "$n" -ge "$COUNT" ] && break
+            if curl -fsSL --max-time 60 \
+                 "https://www.gutenberg.org/ebooks/${id}.epub.noimages" \
+                 -o "corpus/${id}.epub"; then
+              n=$((n+1))
+            else
+              echo "::warning::could not fetch id ${id}, skipping"
+              rm -f "corpus/${id}.epub"
+            fi
+          done
+          echo "fetched $n books"
+          # A shrunken corpus silently weakens the sweep, so fail loudly
+          # rather than passing on two books.
+          if [ "$n" -lt 5 ]; then
+            echo "::error::only $n books fetched; corpus too small to be meaningful"
+            exit 1
+          fi
+
+      - name: Run corpus invariants
+        env:
+          KFXGEN_CORPUS_DIR: corpus
+        run: |
+          pytest tests/integration/test_public_corpus.py -m slow -k invariants -v

--- a/plugin/kfxgen/converter.py
+++ b/plugin/kfxgen/converter.py
@@ -6,6 +6,7 @@ Uses NativeKFXGenerator to produce KFX with working TOC navigation.
 
 import logging
 import os
+import posixpath
 import re
 from urllib.parse import unquote
 
@@ -138,6 +139,35 @@ def _make_img_token(href, alt):
 _URL_SCHEME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.\-]*:")
 
 
+def _resolve_doc_path(base_href, href):
+    """Resolve `href` against the document it appears in, as a book-internal key.
+
+    Anchor keys used to be bare basenames, so `text/notes.xhtml` and
+    `back/notes.xhtml` produced the same key and the first one silently won
+    every link aimed at either. Keeping the directory makes them distinct. (#69)
+
+    A leading `../` is a normal cross-folder link inside an EPUB, so it is
+    resolved rather than rejected — but anything that escapes the book root, is
+    absolute, or fails the shared traversal defenses still returns "". These
+    keys are internal identifiers and never reach the filesystem; the escape
+    check keeps them from naming anything outside the book regardless.
+    """
+    if href and _is_unsafe_href(href) and not href.startswith(".."):
+        _security_log.warning("rejected unsafe href in _resolve_doc_path: %r", href)
+        return ""
+    base = (base_href or "").replace("\\", "/")
+    # An empty href means "this document" — the file itself, not its folder.
+    joined = (
+        posixpath.join(posixpath.dirname(base), href.replace("\\", "/"))
+        if href
+        else base
+    )
+    resolved = posixpath.normpath(joined)
+    if resolved.startswith("..") or resolved.startswith("/") or resolved == ".":
+        return ""
+    return resolved
+
+
 def _resolve_link_target(href, base_href):
     """Normalize an in-book `<a href>` to a "<file>#<fragment>" anchor key.
 
@@ -160,10 +190,10 @@ def _resolve_link_target(href, base_href):
     fragment = _href_fragment(href)
     file_part = href.split("#", 1)[0]
     if file_part:
-        target_file = _normalize_href(file_part)
+        target_file = _resolve_doc_path(base_href, file_part)
     else:
         # Same-file link: "#frag" is relative to the document it appears in.
-        target_file = _normalize_href(base_href) if base_href else ""
+        target_file = _resolve_doc_path(base_href, "") if base_href else ""
     if not target_file:
         return None
     return f"{target_file}#{fragment}" if fragment else target_file
@@ -285,7 +315,7 @@ def _attach_anchor_keys(blocks, base_href):
     """Qualify each block's anchor ids with the file they live in, so a link
     target normalized to "<file>#<id>" can be matched across spine files.
     Stays empty when the caller didn't say which file this is. (#53)"""
-    normalized = _normalize_href(base_href) if base_href else ""
+    normalized = _resolve_doc_path(base_href, "") if base_href else ""
     for block in blocks:
         block["anchor_keys"] = (
             [f"{normalized}#{aid}" for aid in block.get("anchor_ids", ())]

--- a/plugin/kfxgen/native_generator.py
+++ b/plugin/kfxgen/native_generator.py
@@ -36,8 +36,41 @@ _NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
 # below the baseline, so -20% is the closest equivalent. Unlike the
 # superscript value it is NOT device-verified.
 SUPERSCRIPT_FONT_SIZE = 0.75
-SUPERSCRIPT_SHIFT = ("35", "$314")  # +35% of font size
-SUBSCRIPT_SHIFT = ("-20", "$314")  # -20% of font size
+SUPERSCRIPT_SHIFT_PCT = 35  # +35% of font size (device-verified)
+SUBSCRIPT_SHIFT_PCT = -20  # -20% (see #67 — not device-verified)
+
+
+def _env_number(name, default):
+    """Read a numeric env override, falling back to `default` when unset or
+    unparseable. Resolved per call, not at import, so a conversion can be run
+    with a different value without reloading the plugin. (#68)"""
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        return float(raw) if "." in raw else int(raw)
+    except (TypeError, ValueError):
+        _security_log.warning("ignoring invalid %s=%r; using %r", name, raw, default)
+        return default
+
+
+def superscript_metrics():
+    """(font_size, baseline_shift) for a superscript run, env-overridable.
+
+    These are rendering values recovered from a handful of reference files and
+    confirmed on one device model. Exposing them means a Kindle that renders
+    superscripts too high or too small can be corrected without a rebuild. (#68)
+    """
+    size = _env_number("KFXGEN_SUPERSCRIPT_FONT_SIZE", SUPERSCRIPT_FONT_SIZE)
+    pct = _env_number("KFXGEN_SUPERSCRIPT_SHIFT_PCT", SUPERSCRIPT_SHIFT_PCT)
+    return size, (str(pct), "$314")
+
+
+def subscript_metrics():
+    """(font_size, baseline_shift) for a subscript run, env-overridable."""
+    size = _env_number("KFXGEN_SUPERSCRIPT_FONT_SIZE", SUPERSCRIPT_FONT_SIZE)
+    pct = _env_number("KFXGEN_SUBSCRIPT_SHIFT_PCT", SUBSCRIPT_SHIFT_PCT)
+    return size, (str(pct), "$314")
 
 
 #: How many leading blocks may be consumed as a split chapter opener. Two
@@ -2897,11 +2930,9 @@ class NativeKFXGenerator:
             # shift, matching the reference noteref character styles. <sup>
             # wins if a run is somehow marked both. (#52)
             if FLAG_SUPER in flags:
-                attrs["font_size"] = SUPERSCRIPT_FONT_SIZE
-                attrs["baseline_shift"] = SUPERSCRIPT_SHIFT
+                attrs["font_size"], attrs["baseline_shift"] = superscript_metrics()
             elif FLAG_SUB in flags:
-                attrs["font_size"] = SUPERSCRIPT_FONT_SIZE
-                attrs["baseline_shift"] = SUBSCRIPT_SHIFT
+                attrs["font_size"], attrs["baseline_shift"] = subscript_metrics()
             return _allocate_style("_em", **attrs)
 
         # With per-chapter $145 fragments (#2), each chapter's $259

--- a/tests/unit/test_converter.py
+++ b/tests/unit/test_converter.py
@@ -1512,3 +1512,60 @@ def test_first_block_carries_bare_filename_anchor_key():
 def test_bare_filename_key_absent_without_base_href():
     blocks = _conv.extract_blocks_from_html(_doc("<p>x</p>"))
     assert blocks[0]["anchor_keys"] == []
+
+
+# ── #69: anchor keys must be directory-aware ─────────────────────────────────
+
+
+@pytest.mark.unit
+def test_anchor_keys_keep_the_documents_directory():
+    """#69: two files sharing a basename in different folders must not collide."""
+    a = _conv.extract_blocks_from_html(
+        _doc('<p id="n1">front</p>'), base_href="front/notes.xhtml"
+    )
+    b = _conv.extract_blocks_from_html(
+        _doc('<p id="n1">back</p>'), base_href="back/notes.xhtml"
+    )
+    assert a[0]["anchor_keys"] != b[0]["anchor_keys"], (
+        f"same-basename files collided: {a[0]['anchor_keys']}"
+    )
+
+
+@pytest.mark.unit
+def test_link_target_resolves_relative_to_its_own_document():
+    """A sibling href resolves within the linking document's directory."""
+    blocks = _conv.extract_blocks_from_html(
+        _doc('<p><a href="notes.xhtml#n1">x</a></p>'), base_href="text/ch1.xhtml"
+    )
+    assert link_target(blocks[0]["spans"][0][2]) == "text/notes.xhtml#n1"
+
+
+@pytest.mark.unit
+def test_link_target_resolves_parent_directory_reference():
+    """`../back/notes.xhtml` from `text/ch1.xhtml` is a normal cross-folder
+    link and must resolve, not be discarded as traversal."""
+    blocks = _conv.extract_blocks_from_html(
+        _doc('<p><a href="../back/notes.xhtml#n1">x</a></p>'),
+        base_href="text/ch1.xhtml",
+    )
+    assert link_target(blocks[0]["spans"][0][2]) == "back/notes.xhtml#n1"
+
+
+@pytest.mark.unit
+def test_link_target_escaping_the_book_root_is_rejected():
+    """Traversal above the book root stays rejected (SECURITY.md, #44/#60)."""
+    blocks = _conv.extract_blocks_from_html(
+        _doc('<p><a href="../../../etc/passwd">x</a></p>'), base_href="text/ch1.xhtml"
+    )
+    assert (
+        link_target(blocks[0]["spans"][0][2] if blocks[0]["spans"] else frozenset())
+        is None
+    )
+
+
+@pytest.mark.unit
+def test_same_document_fragment_still_resolves():
+    blocks = _conv.extract_blocks_from_html(
+        _doc('<p><a href="#later">x</a></p>'), base_href="text/ch1.xhtml"
+    )
+    assert link_target(blocks[0]["spans"][0][2]) == "text/ch1.xhtml#later"

--- a/tests/unit/test_native_generator.py
+++ b/tests/unit/test_native_generator.py
@@ -2058,3 +2058,31 @@ def test_body_text_matching_title_words_is_not_eaten(tmp_path):
     assert "War and its causes were debated." in texts, (
         f"body paragraph was wrongly consumed as part of the title: {texts}"
     )
+
+
+@pytest.mark.unit
+def test_superscript_metrics_env_override(monkeypatch):
+    """#68: rendering values must be tunable without a rebuild."""
+    from kfxgen import native_generator as ng
+
+    assert ng.superscript_metrics() == (0.75, ("35", "$314"))
+    monkeypatch.setenv("KFXGEN_SUPERSCRIPT_SHIFT_PCT", "50")
+    monkeypatch.setenv("KFXGEN_SUPERSCRIPT_FONT_SIZE", "0.8")
+    assert ng.superscript_metrics() == (0.8, ("50", "$314"))
+
+
+@pytest.mark.unit
+def test_subscript_metrics_env_override(monkeypatch):
+    from kfxgen import native_generator as ng
+
+    assert ng.subscript_metrics() == (0.75, ("-20", "$314"))
+    monkeypatch.setenv("KFXGEN_SUBSCRIPT_SHIFT_PCT", "-30")
+    assert ng.subscript_metrics()[1] == ("-30", "$314")
+
+
+@pytest.mark.unit
+def test_invalid_env_falls_back_to_default(monkeypatch):
+    from kfxgen import native_generator as ng
+
+    monkeypatch.setenv("KFXGEN_SUPERSCRIPT_SHIFT_PCT", "not-a-number")
+    assert ng.superscript_metrics()[1] == ("35", "$314")


### PR DESCRIPTION
Closes #68, #69, #70. Stacked on #65 (which adds the corpus test this workflow runs).

## #69 — basename collision silently mis-targeted links

Anchor keys were bare basenames, so `text/notes.xhtml` and `back/notes.xhtml` produced the same key and the first document won every link aimed at either.

This is the nastiest of the four because it fails *quietly*: the link resolves, so `dangling == 0` holds and the corpus invariants pass while the reader lands in the wrong chapter.

Keys now resolve against the containing document's directory. A leading `../` is an ordinary cross-folder link in an EPUB and now resolves instead of being thrown away; anything escaping the book root, absolute, or failing the shared traversal defenses still returns `""`. These keys are internal identifiers that never reach the filesystem, and there is a test asserting `../../../etc/passwd` stays rejected.

Real book with nested directories: **619 anchors, 643 links, 0 dangling.**

## #68 — typographic constants were unreachable

`$31` shift and superscript font-size are rendering values recovered from a handful of reference files and confirmed on one device model — exactly the kind of value that may need field tuning, and they could only be changed by rebuilding. Now `KFXGEN_SUPERSCRIPT_FONT_SIZE`, `KFXGEN_SUPERSCRIPT_SHIFT_PCT`, `KFXGEN_SUBSCRIPT_SHIFT_PCT`, resolved per call so one conversion can be run with a different value. Defaults unchanged, invalid values warn and fall back.

## #70 — the corpus gate only ran when remembered

Weekly workflow fetching Gutenberg EPUBs **by id** at run time — no corpus in the repo, no book titles anywhere in it. Fails if fewer than 5 books download, so a shrunken corpus cannot pass quietly.

I verified the chain rather than just the YAML: fetched three books over the network and ran the invariants against them — 3 passed.

## #67 — subscript device test

Per your call, `-20%` stays and there is now a book to check it with:

```
~/Desktop/ZZ_SUB_SUPER_TEST.kfx
```

Confirmed to emit both encodings — `$31=-20%` and `$31=35%`, both at `$16=0.75`. It pairs each form with an unmarked baseline line so the comparison is direct, and covers both the `<sub>`/`<sup>` tag route and the CSS `vertical-align` route. #67 stays open until it is sideloaded.

588 tests pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)