### PR TITLE
feat: monthly format-drift watch, notify-only (#46)

### DIFF
--- a/research/kfx-format-baseline/README.md
+++ b/research/kfx-format-baseline/README.md
@@ -16,6 +16,66 @@ snapshot on each future Previewer release and diff.
 - `kfx_inventory.py` — decode a KPF/KFX (via the full `kfxlib` in the installed
   *KFX Input* plugin) → JSON inventory; `--diff` a new inventory vs a baseline.
 - `baseline-gatsby-20260520.json` — the v1 baseline.
+- `check_drift.sh` — monthly watch that says when running the diff is worth it.
+- `com.kfxgen.driftcheck.plist` — `launchd` job for the above.
+
+## Automated watch (#46)
+
+Running the diff on a schedule learns nothing on its own: re-converting the same
+source with the same installed Previewer and `kfxlib` reports "no drift" forever.
+The informative moment is when the *installed* toolchain moves past whatever
+produced the baseline. `check_drift.sh` watches for exactly that.
+
+It is **notify-only**. It reads two version numbers — Kindle Previewer's
+`CFBundleShortVersionString` and `kfxlib/version.py` inside the installed KFX
+Input zip — and compares them to `previewer_version` / `kfxlib_version` in the
+newest committed `baseline-*.json`. It installs nothing, updates nothing, and
+converts nothing, so it is safe to run unattended. Acting on a notification is a
+person's job.
+
+```bash
+./check_drift.sh            # silent unless something moved
+./check_drift.sh --verbose  # always print what it compared
+```
+
+| Exit | Meaning |
+|------|---------|
+| 0 | in sync — silent, so a monthly job is not noise |
+| 1 | a version moved; the diff below is now worth running |
+| 2 | cannot check (Previewer or KFX Input missing, or no baseline) |
+
+On exit 1 it prints the exact commands to run, logs to
+`~/Library/Logs/kfxgen-drift-check.log`, and posts a desktop notification.
+Overridable via `KFXGEN_PREVIEWER_APP`, `KFXGEN_KFX_INPUT_ZIP`,
+`KFXGEN_DRIFT_LOG`.
+
+Note that Previewer reports `3.98` in its Info.plist while the baseline records
+`3.98.0`. Version comparison is component-wise and numeric for that reason — a
+string compare would report drift on the very first run and train you to ignore
+this job.
+
+### Installing the monthly job
+
+`launchd` does not expand `~` or `$HOME` in `ProgramArguments`, so the path must
+be edited before loading:
+
+```bash
+sed "s|REPLACE_WITH_ABSOLUTE_PATH|$(cd ../.. && pwd)|" \
+    com.kfxgen.driftcheck.plist > ~/Library/LaunchAgents/com.kfxgen.driftcheck.plist
+launchctl load ~/Library/LaunchAgents/com.kfxgen.driftcheck.plist
+
+launchctl list | grep kfxgen          # registered?
+launchctl start com.kfxgen.driftcheck # force one run now
+cat ~/Library/Logs/kfxgen-drift-check.log
+```
+
+Remove with `launchctl unload ~/Library/LaunchAgents/com.kfxgen.driftcheck.plist`.
+
+### Owner
+
+Drift notifications go to the repository maintainer, who decides whether the new
+symbols matter to `kfxlib_minimal`. This is a heads-up, not a gate — on-device
+testing remains the real one, and a drift notice never blocks a release.
 
 ## Current baseline
 

--- a/research/kfx-format-baseline/check_drift.sh
+++ b/research/kfx-format-baseline/check_drift.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# Format-drift watch (#46, variant B — notify only).
+#
+# Reports when the local KFX toolchain has moved past the committed baseline,
+# which is the only condition under which running the drift diff can learn
+# anything. It NEVER installs, updates, or converts: it reads two version
+# numbers and compares them. Acting on a notification is the operator's job.
+#
+# Why version-compare rather than "ask Amazon for a new release": re-converting
+# the same source with the same installed Previewer and kfxlib reports "no
+# drift" forever (#46, constraint 2). The informative moment is when the
+# installed tooling differs from what produced the baseline — that is exactly
+# what this detects, with no network access and nothing to break when Amazon
+# changes a download page.
+#
+#   exit 0  nothing to do — silent, so a monthly job is not noise
+#   exit 1  a version moved; the drift diff is now worth running
+#   exit 2  cannot check (Previewer or KFX Input missing)
+#
+# Usage:
+#   ./check_drift.sh            # silent unless action is needed
+#   ./check_drift.sh --verbose  # always print what it compared
+
+set -uo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+VERBOSE=0
+[ "${1:-}" = "--verbose" ] && VERBOSE=1
+
+PREVIEWER_APP="${KFXGEN_PREVIEWER_APP:-/Applications/Kindle Previewer 3.app}"
+PLUGIN_ZIP="${KFXGEN_KFX_INPUT_ZIP:-$HOME/Library/Preferences/calibre/plugins/KFX Input.zip}"
+LOG="${KFXGEN_DRIFT_LOG:-$HOME/Library/Logs/kfxgen-drift-check.log}"
+
+say() { printf '%s\n' "$*"; }
+log() { mkdir -p "$(dirname "$LOG")"; printf '%s  %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$*" >> "$LOG"; }
+
+notify() {
+  # Best-effort desktop notification; a headless launchd context may have no
+  # GUI session, so never let this fail the run.
+  osascript -e "display notification \"$1\" with title \"kfxgen format drift\"" 2>/dev/null || true
+}
+
+# --- the newest committed baseline ------------------------------------------
+BASELINE="$(ls -1 "$DIR"/baseline-*.json 2>/dev/null | sort | tail -1)"
+if [ -z "$BASELINE" ]; then
+  say "no baseline-*.json in $DIR — nothing to compare against"
+  log "ERROR no baseline found"
+  exit 2
+fi
+
+read_json() {  # read_json <file> <key>
+  python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get(sys.argv[2],""))' "$1" "$2"
+}
+
+BASE_PREVIEWER="$(read_json "$BASELINE" previewer_version)"
+BASE_KFXLIB="$(read_json "$BASELINE" kfxlib_version)"
+
+# --- what is installed now ---------------------------------------------------
+if [ ! -d "$PREVIEWER_APP" ]; then
+  say "Kindle Previewer not found at $PREVIEWER_APP"
+  log "ERROR previewer missing"
+  exit 2
+fi
+NOW_PREVIEWER="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' \
+                 "$PREVIEWER_APP/Contents/Info.plist" 2>/dev/null)"
+
+if [ ! -f "$PLUGIN_ZIP" ]; then
+  say "KFX Input plugin not found at $PLUGIN_ZIP"
+  log "ERROR kfx input missing"
+  exit 2
+fi
+NOW_KFXLIB="$(unzip -p "$PLUGIN_ZIP" kfxlib/version.py 2>/dev/null \
+              | sed -nE 's/^__version__ *= *"([^"]+)".*/\1/p')"
+
+if [ -z "$NOW_PREVIEWER" ] || [ -z "$NOW_KFXLIB" ]; then
+  say "could not read installed versions (previewer='$NOW_PREVIEWER' kfxlib='$NOW_KFXLIB')"
+  log "ERROR unreadable versions"
+  exit 2
+fi
+
+# Previewer reports "3.98" in Info.plist while the baseline records "3.98.0".
+# A string compare would call that drift on the very first run and train the
+# operator to ignore this job, so compare zero-padded numeric components.
+same_version() {
+  python3 -c '
+import sys, itertools
+a, b = sys.argv[1], sys.argv[2]
+def parts(v):
+    return [int(x) if x.isdigit() else x for x in v.replace("-", ".").split(".")]
+pa, pb = parts(a), parts(b)
+for x, y in itertools.zip_longest(pa, pb, fillvalue=0):
+    if x != y:
+        sys.exit(1)
+sys.exit(0)' "$1" "$2"
+}
+
+DRIFTED=""
+same_version "$BASE_PREVIEWER" "$NOW_PREVIEWER" || \
+  DRIFTED="$DRIFTED Previewer $BASE_PREVIEWER -> $NOW_PREVIEWER;"
+same_version "$BASE_KFXLIB" "$NOW_KFXLIB" || \
+  DRIFTED="$DRIFTED kfxlib $BASE_KFXLIB -> $NOW_KFXLIB;"
+
+if [ -z "$DRIFTED" ]; then
+  [ "$VERBOSE" = 1 ] && say "no change — Previewer $NOW_PREVIEWER, kfxlib $NOW_KFXLIB, baseline $(basename "$BASELINE")"
+  log "ok previewer=$NOW_PREVIEWER kfxlib=$NOW_KFXLIB (matches $(basename "$BASELINE"))"
+  exit 0
+fi
+
+say "Toolchain moved past the baseline:$DRIFTED"
+say ""
+say "The drift diff can now learn something. Run it (see README):"
+say ""
+say "  cd $DIR"
+say "  curl -sL -o gatsby.epub https://www.gutenberg.org/ebooks/64317.epub3.images"
+say "  \"$PREVIEWER_APP/Contents/MacOS/Kindle Previewer 3\" gatsby.epub -convert -output out/"
+say "  /Applications/calibre.app/Contents/MacOS/calibre-debug kfx_inventory.py -- \\"
+say "      \"$PLUGIN_ZIP\" out/KPF/gatsby.kpf \\"
+say "      --previewer $NOW_PREVIEWER --diff $(basename "$BASELINE")"
+say ""
+say "Nothing has been installed or changed. This job only reads versions."
+log "ACTION$DRIFTED"
+notify "Toolchain moved past baseline:$DRIFTED run the drift diff"
+exit 1

--- a/research/kfx-format-baseline/com.kfxgen.driftcheck.plist
+++ b/research/kfx-format-baseline/com.kfxgen.driftcheck.plist
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Monthly format-drift watch (#46, variant B — notify only).
+
+  Runs check_drift.sh on the 1st of each month at 10:00 local time. The script
+  only reads two version numbers; it installs nothing and converts nothing, so
+  this job is safe to run unattended.
+
+  StartCalendarInterval (not StartInterval) so the schedule is a wall-clock
+  date rather than "every N seconds since load" — and because launchd runs a
+  missed calendar job once after wake, a machine that was asleep on the 1st
+  still gets its check instead of silently skipping the month.
+
+  EDIT THE PATH BELOW before installing: launchd does not expand ~ or $HOME in
+  ProgramArguments.
+
+  Install:
+    cp com.kfxgen.driftcheck.plist ~/Library/LaunchAgents/
+    # replace REPLACE_WITH_ABSOLUTE_PATH first
+    launchctl load ~/Library/LaunchAgents/com.kfxgen.driftcheck.plist
+
+  Verify it is registered, and force one run now:
+    launchctl list | grep kfxgen
+    launchctl start com.kfxgen.driftcheck
+    cat ~/Library/Logs/kfxgen-drift-check.log
+
+  Remove:
+    launchctl unload ~/Library/LaunchAgents/com.kfxgen.driftcheck.plist
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.kfxgen.driftcheck</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>REPLACE_WITH_ABSOLUTE_PATH/research/kfx-format-baseline/check_drift.sh</string>
+    </array>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Day</key>
+        <integer>1</integer>
+        <key>Hour</key>
+        <integer>10</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <!-- The script writes its own timestamped log; these capture anything it
+         does not (a crash, a missing interpreter) so a broken job is visible
+         rather than silent. -->
+    <key>StandardOutPath</key>
+    <string>/tmp/kfxgen-driftcheck.out</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/kfxgen-driftcheck.err</string>
+
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>


### PR DESCRIPTION
Closes #46. Variant **B** (notify-only), per the issue's own recommendation.

## The design point

#46's second constraint is the whole problem: **a blind re-run learns nothing.** Re-converting the same source with the same installed Previewer and `kfxlib` reports "no drift" forever, so a monthly diff would be a ritual that always says fine — and a check that can only say one thing is worse than no check, because it reads as coverage.

What makes the diff informative is the *installed* toolchain moving past whatever produced the baseline. So that is what the job watches:

- Kindle Previewer's `CFBundleShortVersionString`
- `kfxlib/version.py` inside the installed KFX Input zip

compared against `previewer_version` / `kfxlib_version` in the newest committed `baseline-*.json`.

This is deliberately not "ask Amazon whether a new release exists." No network, nothing to break when a download page changes, and no unattended installs. The tradeoff is honest: the job fires when you update your tooling, not the moment Amazon ships. Given Previewer self-updates and Calibre prompts for plugin updates, that lands naturally — and it is precisely the moment a diff would learn something.

## Behaviour

| Exit | Meaning |
|------|---------|
| 0 | in sync — **silent**, so a monthly job is not noise |
| 1 | a version moved; prints the exact diff commands, logs, notifies |
| 2 | cannot check — missing Previewer, plugin, or baseline |

Exit 2 matters: it reports "I could not check" rather than a false all-clear, which is the same class of bug as #78's guard passing on a quarter-size corpus.

## One detail worth calling out

Previewer reports `3.98` in its Info.plist while the baseline records `3.98.0`. A string compare would have reported drift **on the very first run** — the job would have cried wolf immediately and trained you to ignore it, which is exactly the failure it exists to prevent. Comparison is component-wise and numeric.

## Verification

Against the real installed toolchain (Previewer 3.98, kfxlib 20260520, in sync with the baseline):

| Case | Result |
|---|---|
| in sync | silent, exit 0 |
| Previewer moved | exit 1, names the transition |
| kfxlib moved | exit 1, names the transition |
| several baselines present | newest selected |
| Previewer missing | exit 2 |
| KFX Input missing | exit 2 |
| no baseline | exit 2 |

`plutil -lint` passes on the plist, and its `REPLACE_WITH_ABSOLUTE_PATH` placeholder resolves via the documented `sed` to an executable script that runs.

## Deliverables

- `check_drift.sh` — version check, conditional notify
- `com.kfxgen.driftcheck.plist` — monthly `launchd` job, `StartCalendarInterval` so a sleeping machine still gets its check after wake
- README section covering install, exit codes, env overrides, and the owner

The `launchd` agent is **not installed** by this PR — that is a change to a machine, not to the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)