### PR TITLE
fix: disable the upstream probe on the schedule, where it cannot work (#92)

### DIFF
--- a/research/kfx-format-baseline/README.md
+++ b/research/kfx-format-baseline/README.md
@@ -91,6 +91,26 @@ the log, so a persistently broken check is visible there.
 Set `KFXGEN_DRIFT_SKIP_UPSTREAM=1` to disable the upstream check entirely and
 keep only the offline comparison.
 
+#### The upstream check is interactive-only
+
+It does not work under `launchd`, so the shipped plist disables it. Measured on
+the same machine, same script:
+
+| Context | Elapsed | Result |
+|---|---|---|
+| run by hand | ~9-16s | `current` / `available` — correct |
+| run by `launchd` | 100s | hits the 90s ceiling → `unknown`, every time |
+
+Kindle Previewer simply does not finish when a background agent launches it —
+most likely a GUI-session constraint on driving an Aqua app that way. Nothing
+appears on stderr.
+
+The timeout means this costs 90 wasted seconds rather than hanging the job, but
+a check that can only ever return `unknown` is worse than no check: it looks
+installed and healthy while reporting nothing. So the scheduled job runs the
+**offline half only** — which is the half that has actually caught drift — and
+the upstream check is something you run by hand.
+
 On exit 1 it prints the exact commands to run, logs to
 `~/Library/Logs/kfxgen-drift-check.log`, and posts a desktop notification.
 Overridable via `KFXGEN_PREVIEWER_APP`, `KFXGEN_KFX_INPUT_ZIP`,

--- a/research/kfx-format-baseline/com.kfxgen.driftcheck.plist
+++ b/research/kfx-format-baseline/com.kfxgen.driftcheck.plist
@@ -39,6 +39,28 @@
         <string>REPLACE_WITH_ABSOLUTE_PATH/research/kfx-format-baseline/check_drift.sh</string>
     </array>
 
+    <!--
+      The upstream-availability probe is disabled on the schedule because it
+      does not work here. Kindle Previewer completes in ~9s when the script is
+      run by hand and never completes when launchd runs it — measured at 100s,
+      i.e. it hits the script's own 90s ceiling and reports `unknown` every
+      time. Most likely a GUI-session constraint on driving an Aqua app from a
+      background agent.
+
+      The bounded probe means that costs 90 wasted seconds rather than a hang,
+      but a check that can only ever return `unknown` is worse than no check —
+      it looks installed and healthy while reporting nothing. So the scheduled
+      job runs the offline half only, which is the half that has actually
+      caught drift. Run `check_drift.sh` by hand for the upstream check.
+
+      Remove this block to re-enable it once the launchd/GUI issue is solved.
+    -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>KFXGEN_DRIFT_SKIP_UPSTREAM</key>
+        <string>1</string>
+    </dict>
+
     <key>StartCalendarInterval</key>
     <dict>
         <key>Day</key>


### PR DESCRIPTION
Closes nothing; tracked as #92. This is the honest interim state.

## What running the installed agent revealed

I had verified the upstream check by running the script by hand. Running it through `launchd` — the only context that matters for a monthly job — tells a different story:

| Context | Elapsed | Result |
|---|---|---|
| by hand | ~9-16s | `current` / `available` — correct |
| by `launchd` | **100s** | hits the 90s ceiling → `unknown`, every time |

Kindle Previewer does not finish when a background agent launches it. Nothing on stderr, nothing in the agent's stdout capture — it just sits. The first occurrence ran unbounded for minutes before I killed it, which is what prompted the timeout in #90.

## Why disable rather than leave it

The bounded probe meant this cost 90 wasted seconds rather than a hang. But a check that can only ever return `unknown` is **worse than no check** — it looks installed and healthy while reporting nothing. That is the failure shape this repo keeps finding: #76's assertions that could not fail, #78's guard passing a quarter-size corpus, `dangling == 0` satisfied by emitting no links.

Better to disable it visibly, in a plist comment that says exactly why, than to leave it running and useless.

The scheduled job now runs the offline half only — the half that has actually caught drift (3.98.0 → 3.106.0) — and the log records `upstream=skipped`, which is honest about what did and did not happen.

**Measured after the change: 100s → 2s, exit 0.**

## Verification

Reinstalled the live agent from the edited plist and forced a run through `launchctl`, rather than testing the file in isolation:

```
elapsed: 2s  (was 100s)
state: -	0	com.kfxgen.driftcheck
2026-08-02T14:49:10Z  ok previewer=3.106 kfxlib=20260520 (2 baseline(s) current, upstream=skipped)
```

`plutil -lint` passes on both the repo copy and the installed copy. `ruff check` clean.

## Not fixed here

Recovering the upstream signal on the schedule is #92, which lists what is worth trying — `LimitLoadToSessionType`, `launchctl asuser`, or establishing that Previewer needs a window server even for `-log` and closing it as won't-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)