### PR TITLE
fix: allocate image styles in a fixed order, not a set's (#96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## 5.7.2 — Output is byte-reproducible again
+
+**Fixed (#96):** converting the same book twice produced two different files.
+The image `$157` styles were allocated by iterating a **set** of size-class
+names, and CPython randomizes string hashing per interpreter — so a book using
+more than one image size class allocated `s_img`, `s_img_sm` and `s_img_page`
+in a different order each run. Every local symbol numbered after them shifted,
+which moved `$270`'s symbol ids and `$419`'s name list. Iterating a fixed
+sequence and skipping the classes not present fixes it.
+
+Reading was never affected: across runs every `$145`, `$259`, `$265` and every
+`$266` anchor was already byte-identical. What this cost was the corpus A/B
+diff, which reported a standing difference in those three fragments on any
+image-bearing book, so real churn had to be picked out of permanent noise.
+Three conversions of a 910,818-character book at different hash seeds now
+produce one identical file; before, three different ones.
+
+The single-image golden fixtures could not catch this — one size class means
+one iteration order. `referenced_targets` already sorted before iterating; this
+was the site that didn't.
+
+**Testing:** an integration test converts the same input in three subprocesses
+under different `PYTHONHASHSEED` values and compares digests. It has to cross a
+process boundary — hash randomization is per interpreter, so a same-process
+double conversion passes while the defect is still there. Its fixture pairs a
+`SOF0`-bearing JPEG with `MINIMAL_JPEG` (which has no `SOF` and so classifies
+as `inline`) to put two size classes in one book.
+
 ## 5.7.1 — Return links land on the marker, not the paragraph
 
 **Fixed (#79):** tapping a note's return link dropped you at the top of the

--- a/plugin/kfxgen/__init__.py
+++ b/plugin/kfxgen/__init__.py
@@ -12,7 +12,7 @@ __copyright__ = "2025-2026, Justin Loutsch <justin.loutsch@gmail.com>"
 
 #: Version tuple. Bump this for every release; the plugin wrapper and
 #: converter log message read from here.
-version = (5, 7, 1)
+version = (5, 7, 2)
 __version__ = ".".join(str(x) for x in version)
 
 __all__ = [

--- a/plugin/kfxgen/native_generator.py
+++ b/plugin/kfxgen/native_generator.py
@@ -3071,7 +3071,16 @@ class NativeKFXGenerator:
                     w, h = resource_to_dims.get(c.get("resource"), (None, None))
                     kinds_used.add(_classify(w, h))
 
-            for kind in kinds_used:
+            # Fixed order, not the set's. Iterating `kinds_used` directly made
+            # the output non-reproducible: CPython randomizes string hashing
+            # per interpreter, so a book using more than one size class
+            # allocated these $157 styles in a different order each run, and
+            # every local symbol numbered after them shifted with it — $270's
+            # symbol ids and $419's name list changed while the content was
+            # byte-identical. (#96)
+            for kind in ("small", "inline", "page"):
+                if kind not in kinds_used:
+                    continue
                 name = {"small": "s_img_sm", "inline": "s_img", "page": "s_img_page"}[
                     kind
                 ]

--- a/tests/integration/test_reproducible_output.py
+++ b/tests/integration/test_reproducible_output.py
@@ -1,0 +1,115 @@
+"""Converting the same book twice must produce the same bytes (#96).
+
+The defect this pins is per-process: CPython randomizes string hashing, so a
+set iterated in one interpreter can yield a different order in the next. A
+same-process double conversion cannot see it — these tests run the conversion
+in subprocesses with different PYTHONHASHSEED values.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _jpeg(width: int, height: int) -> bytes:
+    """A JPEG carrying a SOF0 with the given dimensions, which is all the size
+    classifier reads.
+
+    `MINIMAL_JPEG` has no SOF at all and so classifies as `inline`; pairing it
+    with this one puts two size classes in one book, which is what makes the
+    allocation order observable. Padded past 100 bytes with a comment segment
+    because `converter.py` drops anything smaller as not-really-an-image.
+    """
+    pad = b"kfxgen reproducibility fixture padding. " * 4
+    comment = b"\xff\xfe" + bytes([(len(pad) + 2) >> 8, (len(pad) + 2) & 0xFF]) + pad
+    return (
+        b"\xff\xd8"
+        + comment
+        + b"\xff\xc0\x00\x11\x08"
+        + bytes([height >> 8, height & 0xFF, width >> 8, width & 0xFF])
+        + b"\x03\x01\x11\x00\x02\x11\x01\x03\x11\x01"
+        + b"\xff\xd9"
+    )
+
+
+_SCRIPT = textwrap.dedent(
+    """
+    import sys, hashlib
+    from pathlib import Path
+    root = Path(sys.argv[1])
+    sys.path.insert(0, str(root))
+    sys.path.insert(0, str(root / "plugin"))
+    from kfxgen import converter
+    from tests._helpers import MINIMAL_JPEG, NullLog
+    from tests.fixtures.epub_builder import EpubBuilder
+    from tests.fixtures.oeb_shim import EpubAsOeb
+    from tests.integration.test_reproducible_output import _jpeg
+
+    out = Path(sys.argv[2])
+    body = (
+        '<p>Opening paragraph.</p>'
+        '<p><img src="page.jpg" alt="a page-sized image"/></p>'
+        '<p>Middle paragraph.</p>'
+        '<p><img src="tiny.jpg" alt="an unsized image"/></p>'
+        '<p>Closing paragraph.</p>'
+    )
+    page = (
+        '<?xml version="1.0" encoding="utf-8"?>\\n'
+        '<html xmlns="http://www.w3.org/1999/xhtml">'
+        '<head><title>Images</title></head><body>' + body + '</body></html>'
+    )
+    epub = (
+        EpubBuilder()
+        .set_metadata(title="Repro", author="Repro Author")
+        .add_chapter("Images", page.encode())
+        .add_chapter("Plain", "<p>Second chapter body.</p>".encode())
+        .add_manifest_item(
+            item_id="page", href="page.jpg", media_type="image/jpeg",
+            data=_jpeg(700, 700),
+        )
+        .add_manifest_item(
+            item_id="tiny", href="tiny.jpg", media_type="image/jpeg",
+            data=MINIMAL_JPEG,
+        )
+        .build(out, "repro")
+    )
+    kfx = out / "repro.kfx"
+    converter.convert_oeb_to_kfx(EpubAsOeb(epub), str(kfx), opts=None, log=NullLog())
+    print(hashlib.sha256(kfx.read_bytes()).hexdigest())
+    """
+)
+
+
+def _convert_with_seed(seed: str, work: Path) -> str:
+    env = dict(os.environ, PYTHONHASHSEED=seed)
+    out = work / f"seed{seed}"
+    out.mkdir(parents=True, exist_ok=True)
+    proc = subprocess.run(
+        [sys.executable, "-c", _SCRIPT, str(_ROOT), str(out)],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(_ROOT),
+    )
+    assert proc.returncode == 0, f"conversion failed:\n{proc.stderr[-2000:]}"
+    return proc.stdout.strip().splitlines()[-1]
+
+
+@pytest.mark.integration
+def test_same_book_converts_to_identical_bytes_across_processes(tmp_path):
+    """A book with more than one image size class must still be reproducible.
+
+    The image `$157` styles were allocated by iterating a set of size-class
+    names, so their order — and every local symbol id numbered after them —
+    varied per interpreter. (#96)
+    """
+    digests = {seed: _convert_with_seed(seed, tmp_path) for seed in ("0", "1", "2")}
+    assert len(set(digests.values())) == 1, (
+        f"Conversion is not reproducible across processes: {digests}"
+    )


### PR DESCRIPTION
Closes #96.

## The defect

Converting the same book twice produced two different files.

`native_generator.py` allocated the image `$157` styles by iterating a **set** of size-class names. CPython randomizes string hashing per interpreter, so a book using more than one image size class allocated `s_img`, `s_img_sm` and `s_img_page` in a different order each run. Every local symbol numbered after them shifted, which moved `$270`'s symbol ids and `$419`'s name list.

```python
for kind in kinds_used:            # set of strings — order varies per process
    name = {"small": "s_img_sm", "inline": "s_img", "page": "s_img_page"}[kind]
```

Now iterates a fixed sequence and skips the classes not present.

## Impact

Reading was never affected — across runs every `$145`, `$259`, `$265` and every `$266` anchor was already byte-identical. What this cost was the corpus A/B diff (`research/baseline_runner.py`), which reported a standing difference in those three fragments for any image-bearing book, so real churn had to be picked out of permanent noise. It also meant "byte-identical" wasn't usable as a clean regression signal for books with images.

## Verification

Three conversions of a 910,818-character book at `PYTHONHASHSEED` 0, 1 and 2:

| | before | after |
|---|---|---|
| distinct outputs from 3 runs | 3 | 1 |

## Testing

An integration test converts the same input in three subprocesses under different `PYTHONHASHSEED` values and compares digests.

Two details that matter:

- **It must cross a process boundary.** Hash randomization is per interpreter, so a same-process double conversion passes while the defect is still there.
- **Three seeds, not two.** When I ran it against the unfixed code, seeds 0 and 1 agreed and only seed 2 diverged — two seeds would have been a coin flip.

The fixture pairs a `SOF0`-bearing JPEG with `MINIMAL_JPEG` (no `SOF`, so it classifies as `inline`) to get two size classes into one book, padded past the converter's 100-byte floor for what counts as an image. The existing single-image golden fixtures could not catch this: one size class means one iteration order whatever the seed.

622 passing, ruff check and format clean. All eight golden fixtures byte-identical.

## Note for the merge

Version bumped to 5.7.2. The `v5.7.2` tag needs pushing on merge or the Release won't publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)