### PR TITLE
fix: make tier-2 runnable as documented (#99)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,12 @@ To run the tier-2 test, supply the zip locally at
 `tests/fixtures/vendor/kfx_input_plugin.zip` using the procedure below; the
 test skips cleanly when the file is absent, so CI without it still passes.
 
+Running it also needs `Pillow` and `beautifulsoup4`, which upstream `kfxlib`
+imports and kfxgen does not. Both are in `requirements-dev.txt`; if you set up
+before they were added, re-run `pip install -r requirements-dev.txt` or the
+suite errors at setup rather than skipping. That gap went unnoticed for as long
+as nobody ran tier-2, which is the point #99 is about.
+
 **Setup / refresh procedure** (supply the zip, or refresh it when upstream
 Calibre's KFX Input plugin ships a new version worth diffing against):
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -31,6 +31,10 @@ uharfbuzz>=0.38.0
 # suite nobody runs — following CONTRIBUTING's tier-2 procedure produced 32
 # setup errors instead of a result, and had for as long as nobody looked (#99).
 #
+# The "#104" that removed it lives in this project's PRIVATE tracker, not here.
+# Do not chase it in this repo: numbering has grown past it and #104 now
+# resolves to an unrelated pull request.
+#
 # beautifulsoup4 is the second option in upstream's soup-parser fallback chain
 # (calibre.utils.soupparser -> bs4 -> BeautifulSoup). With it present, tier-2
 # runs outside Calibre's interpreter; without it, the chain exhausts and the

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,6 +23,22 @@ sphinx-rtd-theme>=2.0.0
 # HarfBuzz (text shaping - will be critical for Phase 2)
 uharfbuzz>=0.38.0
 
+# Needed to IMPORT jhowell's kfxlib in the tier-2 differential decode
+# (tests/integration/test_kfxlib_diff.py). kfxgen itself uses neither.
+#
+# Pillow is not a re-add of the dependency #104 removed: that was kfxgen's own
+# unused import. This is upstream kfxlib's, and removing ours quietly broke a
+# suite nobody runs — following CONTRIBUTING's tier-2 procedure produced 32
+# setup errors instead of a result, and had for as long as nobody looked (#99).
+#
+# beautifulsoup4 is the second option in upstream's soup-parser fallback chain
+# (calibre.utils.soupparser -> bs4 -> BeautifulSoup). With it present, tier-2
+# runs outside Calibre's interpreter; without it, the chain exhausts and the
+# error surfaces as "No module named 'calibre'", which reads as "this can only
+# run inside Calibre" and is misleading.
+Pillow>=10.0.0
+beautifulsoup4>=4.12.0
+
 # Development tools (optional, Python 3.10+ only)
 # ipython>=8.20.0
 # ipdb>=0.13.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,20 @@
 # kfxgen Core Dependencies
 #
-# Exact pins (#103). At runtime the Calibre plugin uses Calibre's own
-# bundled libraries, NOT these — requirements.txt is for dev/standalone
-# use. Security-sensitive parsers (lxml, cssutils, fonttools) are
+# Exact pins (private tracker, issue 103). At runtime the Calibre plugin
+# uses Calibre's own bundled libraries, NOT these — requirements.txt is
+# for dev/standalone use. Security-sensitive parsers (lxml, cssutils, fonttools) are
 # pinned exactly per the project security standard so an untrusted
 # EPUB never reaches an unvetted parser version. Bump deliberately,
 # not implicitly. lxml is pinned to the version the test suite
-# validates against (.venv); the rest to current stable. (Pillow was
-# removed in #104 as an unused dependency.)
+# validates against (.venv); the rest to current stable.
+#
+# Pillow was removed here as unused by kfxgen. It is back in
+# requirements-dev.txt, because upstream kfxlib imports it and the tier-2
+# differential decode could not run without it.
+#
+# The bare issue numbers in this file predate the public repo and refer to
+# its PRIVATE tracker. Written de-linked on purpose: this repo's numbering
+# has now grown past them, so `#103` would auto-link to an unrelated PR here.
 
 # Amazon Ion serialization (KFX foundation)
 amazon-ion==0.13.0


### PR DESCRIPTION
First concrete step on #99. This does **not** make tier-2 gate anything — it makes it possible to run at all, which turns out to be a prerequisite nobody had checked.

## What I found

Following `CONTRIBUTING.md` → *The upstream kfxlib copy* exactly — copy the plugin zip into `tests/fixtures/vendor/`, run `pytest -m tier2` — does not produce a result. It produces **32 setup errors**.

Three layers, each of which sent me somewhere slightly wrong:

1. `ModuleNotFoundError: No module named 'PIL'`. Upstream `kfxlib` imports PIL at module level. **Pillow was removed from requirements as "an unused dependency"** (in this project's *private* tracker — the number in requirements.txt is not a reference to anything in this repo) — true of kfxgen, which does not use it, and it quietly broke the one suite that does.
2. Then `bs4`, then `BeautifulSoup`. Upstream has a fallback chain: `calibre.utils.soupparser` → `bs4` → `BeautifulSoup`.
3. With none installed the chain exhausts and the visible error is `No module named 'calibre'` — which reads as *"tier-2 can only run inside Calibre's interpreter"* and is wrong. It just needs `beautifulsoup4`.

## The result nobody had

With both installed:

```
47 passed, 621 deselected in 1.95s
```

against `kfxlib` 20260520, matching the committed pin.

As far as I can tell that is the first recorded result from actually running this suite. #91 cited *"tier-2 passes (43 tests)"* as evidence nothing was broken; that cannot have come from this environment, because this environment errors.

## Why this belongs to #99

The issue argues a check that does not gate anything is invisible rather than merely uninformative. This is that, demonstrated: a dependency removal correct for everything that runs broke the only thing that does not, and it stayed broken silently. The rot was not in the test — the test is fine, 47 pass — it was in the ability to run it.

## What changed

- `requirements-dev.txt` — `Pillow` and `beautifulsoup4`, with the reasoning inline so the Pillow line is not mistaken for a revert of #104. Both are for importing upstream `kfxlib` in tests; kfxgen uses neither.
- `CONTRIBUTING.md` — says so in the tier-2 section, and tells anyone who set up earlier to re-install.

## Still open in #99

Whether tier-2 gates anything, and the conversation with jhowell about the plugin zip. Those are unchanged. This just means that when someone acts on them, the suite will run.

## Note

One finding this surfaces but does not address: tier-2 passes while upstream reports `ERROR: Unreferenced fragments` on our output (#102). The suite tolerates a documented noise floor, and that error is inside it. Worth revisiting once #102 is fixed — a tolerated ERROR is a strange thing to have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
