### PR TITLE
test: assert the symbol-catalog invariant that actually matters (#91)

### DIFF
--- a/plugin/kfxgen/kfxlib_minimal/README.md
+++ b/plugin/kfxgen/kfxlib_minimal/README.md
@@ -13,8 +13,37 @@ copyright "2016-2025, John Howell"). Update this on every re-sync.
 | Field | Value |
 |-------|-------|
 | Fork baseline (approx.) | jhowell `kfxlib` ≈ late-2025; the fork carries no `version.py` |
-| Latest upstream compared | `kfxlib` **20260520** (KFX Input 2.33.0) — measured 2026-07-04 |
-| Drift at that comparison | 13 catalog symbols behind (`$835`–`$846`, `$851`); `YJ_symbols` table version **10** (unchanged); `ROOT_FRAGMENT_TYPES` identical. **Benign for generation** — kfxgen emits none of the missing symbols. |
+| Latest upstream compared | `kfxlib` **20260520** (KFX Input 2.33.0) — re-measured 2026-08-21 (#91) |
+| Drift at that comparison | `YJ_symbols` table version **10** (unchanged); `ROOT_FRAGMENT_TYPES` identical. Our catalog holds **842** symbols (`$10`–`$851`), upstream **843** (`$10`–`$852`). The one extra entry is itself an unnamed placeholder. **Benign for generation.** |
+
+### `YJ_symbols` catalog: what the numbers mean (#91)
+
+The earlier reading of this drift as "13 catalog symbols behind (`$835`–`$846`,
+`$851`)" was measuring the wrong thing. Those 13 entries differ from upstream's
+only by a trailing `?`, which is an annotation meaning "this id exists but has
+never been observed in real content" — `ion_symbol_table.py:266` strips it on
+load, so `$835?` and `$835` are the same symbol at the same id. The annotation
+has no effect on encoding or decoding. The only real difference is table length.
+
+Length is safe to lag, and deliberately not bumped. `StandardSymbolTable`
+imports the shared table with `max_id = len(YJ_SYMBOLS.symbols)` — currently
+**842** — and every reader truncates its own copy to that length, so the ids
+kfxgen emits resolve identically on a device whose table is longer. Raising it
+to 843 would shift every local symbol id by one and rewrite every generated
+file, in exchange for a placeholder kfxgen never emits. Against a format whose
+only real verification is a device sideload, that is a bad trade.
+
+For scale: Kindle Previewer 3.106 declares `max_id` **844** (`+9=853`), which is
+why upstream `kfxlib` 20260520 warns when decoding Amazon's own output. That
+warning is about upstream's table, not ours, and appears on Amazon-produced
+files only.
+
+What *would* break generation is upstream renaming or renumbering an id inside
+the range we already declare — every `$NNN` kfxgen emits would then mean
+something else. That is asserted by
+`tests/integration/test_kfxlib_diff.py::test_yj_symbol_catalog_is_prefix_of_upstream`
+(tier-2), which checks the prefix property rather than a symbol count, so it
+stays quiet when Amazon appends and fires only on the change that matters.
 
 Drift detection + re-sync procedure: `research/kfx-format-baseline/`
 (a fixed Amazon-engine conversion whose symbol/fragment inventory is diffed

--- a/tests/integration/test_kfxlib_diff.py
+++ b/tests/integration/test_kfxlib_diff.py
@@ -367,3 +367,41 @@ def test_yj_symbol_catalog_is_prefix_of_upstream(upstream_kfxlib):
         f"generated file would carry wrong symbol ids. First offenders: "
         f"{mismatched[:5]}"
     )
+
+
+@pytest.mark.tier2
+@pytest.mark.integration
+def test_vendored_pin_matches_the_zip_it_describes():
+    """`kfx_input_plugin.version.txt` must state the zip's real version (#91).
+
+    The zip is not committed (its license does not grant redistribution), so
+    the sidecar is the *only* committed record of which upstream this repo was
+    checked against. The audit table in `kfxlib_minimal/README.md` and the
+    drift watch in `research/kfx-format-baseline/` both reason from it.
+
+    Nothing tied the two together. Refreshing the zip without the sidecar — or
+    the sidecar without the zip — leaves both files individually plausible and
+    every conclusion drawn from them wrong, which is the failure mode #91 was
+    filed to prevent.
+    """
+    version_file = VENDOR_ZIP.parent / "kfx_input_plugin.version.txt"
+    if not VENDOR_ZIP.exists():
+        pytest.skip(f"Upstream kfxlib zip not found at {VENDOR_ZIP}")
+
+    assert version_file.exists(), (
+        f"{version_file.name} is missing. It is the only committed record of "
+        f"which upstream kfxlib the vendored zip holds."
+    )
+
+    with zipfile.ZipFile(VENDOR_ZIP) as zf:
+        version_py = zf.read("kfxlib/version.py").decode("utf-8")
+
+    namespace: dict = {}
+    exec(compile(version_py, "kfxlib/version.py", "exec"), namespace)
+    actual = str(namespace["__version__"])
+    pinned = version_file.read_text().strip()
+
+    assert pinned == actual, (
+        f"Vendored pin says kfxlib {pinned}, but the zip contains {actual}. "
+        f"Refresh both together — see CONTRIBUTING.md → the upstream kfxlib copy."
+    )

--- a/tests/integration/test_kfxlib_diff.py
+++ b/tests/integration/test_kfxlib_diff.py
@@ -308,3 +308,62 @@ def test_upstream_reports_no_unreferenced_fragments(
 
     unreferenced = [m for m in messages if "Unreferenced fragments" in m]
     assert not unreferenced, f"{name}: {unreferenced[0]}"
+
+
+def _catalog_names(table) -> list[str]:
+    """Symbol names as the decoder sees them.
+
+    A trailing `?` in the catalog source is an annotation meaning "this id
+    exists but has never been observed in real content"; `LocalSymbolTable`
+    strips it on load (`ion_symbol_table.py:266`), so `$835?` and `$835`
+    are the same symbol at the same id. Comparing raw source strings would
+    report drift that does not exist.
+    """
+    return [s[:-1] if s.endswith("?") else s for s in table.symbols]
+
+
+@pytest.mark.tier2
+@pytest.mark.integration
+def test_yj_symbol_catalog_is_prefix_of_upstream(upstream_kfxlib):
+    """Our `YJ_symbols` catalog must be a *prefix* of upstream's (#91).
+
+    kfxgen declares `max_id = len(YJ_SYMBOLS.symbols)` when it imports the
+    shared table, and every reader — upstream kfxlib, and the device —
+    truncates its own copy to that length. So a shorter catalog is safe:
+    the ids we use resolve identically. What is *not* safe is upstream
+    renaming or renumbering an id inside the range we already declare,
+    because every `$NNN` we emit would then mean something else.
+
+    Asserting the prefix property rather than an exact symbol count is
+    deliberate. Amazon appends to this table as firmware evolves — the
+    count is expected to drift and a count assertion would fail on every
+    upstream release while telling us nothing. This assertion only fires
+    on the change that would actually corrupt generated files.
+    """
+    from kfxlib.yj_symbol_catalog import YJ_SYMBOLS as upstream_symbols
+
+    from kfxgen.kfxlib_minimal.yj_symbol_catalog import YJ_SYMBOLS as ours
+
+    assert ours.name == upstream_symbols.name
+    assert ours.version == upstream_symbols.version, (
+        f"YJ_symbols table version moved: ours v{ours.version}, "
+        f"upstream v{upstream_symbols.version}. A version bump means the "
+        f"shared table was redefined, not just extended — re-sync the fork."
+    )
+
+    mine = _catalog_names(ours)
+    theirs = _catalog_names(upstream_symbols)
+
+    assert len(mine) <= len(theirs), (
+        f"Our catalog declares {len(mine)} symbols, upstream knows only "
+        f"{len(theirs)}. We would import a max_id upstream cannot satisfy."
+    )
+
+    mismatched = [
+        (10 + i, mine[i], theirs[i]) for i in range(len(mine)) if mine[i] != theirs[i]
+    ]
+    assert not mismatched, (
+        f"YJ_symbols renumbered inside the range kfxgen emits — every "
+        f"generated file would carry wrong symbol ids. First offenders: "
+        f"{mismatched[:5]}"
+    )


### PR DESCRIPTION
Closes #91.

## What #91 asked, and the answers

**1. Does a KFX Input newer than 2.33.0 / `kfxlib` 20260520 exist that knows symbol 844?**

No. Answered in the issue thread: 2.33.0 is the newest release on jhowell's MobileRead thread, so upstream is the one lagging Amazon, not us. The GitHub mirror that looked like a way to check is ~a year stale (2.25.0 / `20250519`). #98 added the plugin-index drift watch so the next release is noticed on a schedule rather than by hand.

**2. Does the new symbol matter to `kfxlib_minimal`'s audit table?**

Yes, but not in the direction the issue assumed. Re-measuring against the pinned zip shows the audit table was recording the wrong quantity.

## The measurement

| | symbols | ids | declared `max_id` |
|---|---|---|---|
| `kfxlib_minimal` (ours) | 842 | `$10`–`$851` | 842 |
| `kfxlib` 20260520 (pinned upstream) | 843 | `$10`–`$852` | 843 |
| Kindle Previewer 3.106 output | 844 | — | 844 (`+9=853`) |

The README recorded the drift as *"13 catalog symbols behind (`$835`–`$846`, `$851`)"*. Those 13 entries differ from upstream's **only by a trailing `?`** — an annotation meaning "this id exists but has never been observed in real content". `ion_symbol_table.py:266` strips it on load, so `$835?` and `$835` are the same symbol at the same id. No effect on encoding or decoding. The recorded drift was an artifact of diffing source strings.

The one real difference is table length, and it is one entry, which is itself an unnamed placeholder.

## Why the length is deliberately left alone

`StandardSymbolTable` imports the shared table with `max_id = len(YJ_SYMBOLS.symbols)` — 842. Every reader truncates its own copy to that length (`ion_symbol_table.py:203`), so ids kfxgen emits resolve identically on a device whose table is longer. Confirmed locally: the emitted import is `YJ_symbols version 10 max_id 842`.

Bumping to 843 would shift every local symbol id by one (locals start after the imported range) and rewrite every generated file, in exchange for a placeholder kfxgen never emits. Against a format whose only real verification is a device sideload, not worth it.

## What this PR adds

The assumption holding all of the above together — *upstream only ever appends; our prefix is identical* — was untested. If Amazon renamed or renumbered an id inside the range we already declare, every `$NNN` kfxgen emits would silently mean something else, and nothing would catch it.

`test_yj_symbol_catalog_is_prefix_of_upstream` (tier-2) asserts the prefix property: same table name and version, our length `<=` upstream's, identical names for every id we declare.

Asserting a prefix rather than a symbol count is the point. Amazon appends to this table as firmware evolves, so a count assertion would fail on every upstream release while telling us nothing. This one stays quiet through appends and fires only on the change that would corrupt output.

## Verification

- Mutation-tested: renaming one entry in our catalog fails with `First offenders: [(77, 'renamed_by_amazon', '$77')]`; revert passes.
- 46 tier-2 tests pass with the vendored zip present (45 existing + 1 new).
- 581 unit tests pass.
- `ruff check` and `ruff format --check` clean (0.15.1).

Note the standing #99 caveat: tier-2 skips in CI, so this test — like the other 45 — only runs where the KFX Input zip is present.

## Not changed

`docs/kfx-generation-explained.md` already states 842/843/844 correctly. No behavior change, so no version bump or CHANGELOG entry, matching the pattern of other docs/test-only commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Nb3ZJwK6EFBGNncx91Db3