### PR TITLE
docs: correct standard_symbols.py attribution

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -21,6 +21,14 @@ plugin/kfxgen/kfxlib_minimal/
     packaging changes on top. The list of local modifications is kept in
     plugin/kfxgen/kfxlib_minimal/README.md.
 
+    Not every file in that directory is derived from kfxlib.
+    standard_symbols.py is original kfxgen work, copyright Justin Loutsch:
+    its symbol names were harvested by decoding Kindle Previewer output,
+    and none of them appears in upstream kfxlib. It sits in that directory
+    only because it subclasses the vendored LocalSymbolTable. Per-file
+    copyright headers are authoritative where they disagree with this
+    directory-level summary.
+
     The upstream KFX plugins are available from the MobileRead forums.
     kfxgen does not redistribute jhowell's plugin packages themselves;
     only this modified source subset is included, as permitted by the

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Copyright © 2025-2026 Justin Loutsch &lt;justin.loutsch@gmail.com&gt;
 
 ## Credits
 
-- **kfxlib** by John Howell — Ion/KFX libraries, GPL v3. The `kfxlib_minimal/` directory is a modified subset of this work; see [NOTICE](NOTICE) and `plugin/kfxgen/kfxlib_minimal/README.md`.
+- **kfxlib** by John Howell — Ion/KFX libraries, GPL v3. Most of the `kfxlib_minimal/` directory is a modified subset of this work; `standard_symbols.py` is not, despite living there. See [NOTICE](NOTICE) and `plugin/kfxgen/kfxlib_minimal/README.md`.
 - **Calibre** by Kovid Goyal — plugin framework
 
 ---

--- a/docs/kfx-generation-explained.md
+++ b/docs/kfx-generation-explained.md
@@ -459,9 +459,11 @@ there, and tracked in #91.
 
 ### The encoding layer
 
-`kfxlib_minimal` is a trimmed copy of jhowell's `kfxlib`, carrying the Ion
-binary and text codecs, the symbol table machinery, and the KFX/YJ container
-readers and writers. kfxgen does not implement Ion itself.
+`kfxlib_minimal` is mostly a trimmed copy of jhowell's `kfxlib`, carrying the
+Ion binary and text codecs, the symbol table machinery, and the KFX/YJ container
+readers and writers. kfxgen does not implement Ion itself. (One file there,
+`standard_symbols.py`, is original kfxgen work rather than vendored — see that
+directory's README.)
 
 That is a deliberate boundary. Bugs in serialization are upstream's territory
 and get fixed by re-syncing the copy; bugs in *what we serialize* are ours.

--- a/plugin/kfxgen/kfxlib_minimal/README.md
+++ b/plugin/kfxgen/kfxlib_minimal/README.md
@@ -84,18 +84,45 @@ with future upstream syncs. Audit when bumping the upstream baseline.
 | Date | Issue | PR | Modification |
 |---|---|---|---|
 | 2025-12-31 | — | (initial) | Trimmed upstream `kfxlib` to the minimum surface needed by kfxgen (Ion binary/text/symbol-table, kfx/yj container, message logging). Heavy deps (pypdf, PIL, lxml-only paths) removed. |
-| 2026-01-05 | — | (foundation) | `standard_symbols.py` and `yj_symbol_catalog.py` populated for native KFX generation (Phase 1 — gap fix + standard symbols). |
+| 2026-01-05 | — | (foundation) | `yj_symbol_catalog.py` populated for native KFX generation (Phase 1 — gap fix). Derived from upstream; ~97% shared with `kfxlib` 20260520. |
+| 2026-01-05 | — | (foundation) | `standard_symbols.py` added. **Not derived from upstream** — see the note below. Original kfxgen work that happens to live in this directory. |
 | 2026-02-17 | — | v5.1.0 | Lint pass: unused imports removed, lambda assignment replaced. Mechanical only. |
 | 2026-03-02 | — | v5.2.0 | TOC off-by-one fixes touched serialization paths in this directory. |
 | 2026-05-03 | issue 47 | PR 66 | `Deserializer.extract` length-field bound (`MAX_DECODE_SIZE`, default 64 MB). Negative-size and oversized-size paths raise distinct errors BEFORE the slice. Single choke point defends every length-bounded read in `ion_binary.py`. |
 | 2026-05-03 | issue 47 | (PR D) | `MAX_DECODE_SIZE` accepts `KFXGEN_MAX_DECODE_SIZE` env override at import time. Default unchanged (64 MB). See [SECURITY.md → Advanced configuration](../../../SECURITY.md). |
 | 2026-05-03 | — | PR 56/PR 67 | Pre-commit framework added at repo root; ruff format/lint may have touched files in this directory. Mechanical only. |
+| 2026-08-21 | — | PR 110 | Corrected `standard_symbols.py`'s copyright header, which a directory-wide attribution sweep (#4) had credited to John Howell. See below. |
 
 To regenerate this list:
 
 ```bash
 git log --diff-filter=AM --pretty='%h %ad %s' --date=short -- plugin/kfxgen/kfxlib_minimal/
 ```
+
+### `standard_symbols.py` is not vendored code
+
+Everything else in this directory is derived from upstream `kfxlib`. That file is
+not, and the distinction is easy to lose because of where it sits.
+
+Measured against `kfxlib` 20260520: no upstream module defines these names, no
+`standard_symbols.py` exists upstream at all, and **0 of its 247 symbols** appear
+anywhere in that source as string literals. `STANDARD_SYMBOLS` holds *local*
+symbol names — content and style names such as `c0`, `c1AJ-ad`, `s28K`, `sV5` —
+harvested by decoding Kindle Previewer output. Same provenance as the rest of
+kfxgen's format knowledge: observation of Amazon's own files, not upstream source.
+
+It lives here because `StandardSymbolTable` subclasses the vendored
+`LocalSymbolTable`. That places it in the same GPL v3 combined work, which it
+already was project-wide, but subclassing does not transfer authorship.
+
+Commit `b2a1782` (#4) added an identical attribution header to six files in this
+directory in one pass. It was right about five and wrong about this one; the
+header now names the actual author. Worth remembering when the next
+directory-wide sweep is tempting — this directory is not uniform.
+
+For contrast, `__init__.py` carries no attribution header and keeps none. It is
+original packaging work, but what it re-exports is upstream's API surface, which
+puts it closer to derived than `standard_symbols.py` rather than further.
 
 ## Why a fork instead of pinning Calibre's `kfxlib`?
 

--- a/plugin/kfxgen/kfxlib_minimal/README.md
+++ b/plugin/kfxgen/kfxlib_minimal/README.md
@@ -1,14 +1,21 @@
 # kfxlib_minimal
 
-A trimmed fork of Calibre's `kfxlib`, copied into kfxgen so the plugin
+Mostly a trimmed fork of Calibre's `kfxlib`, copied into kfxgen so the plugin
 runs inside Calibre's bundled Python interpreter without pulling in
 heavy upstream dependencies (pypdf, PIL, etc.). Only the Ion structures
 and serialization utilities needed for KFX generation are kept.
 
+**The directory is not uniform.** `standard_symbols.py` is original kfxgen work
+and `__init__.py` is original packaging; everything else is derived from
+upstream. See [`standard_symbols.py` is not vendored code](#standard_symbolspy-is-not-vendored-code)
+below before drawing any conclusion about provenance from this directory's name.
+
 ## Upstream baseline (#18)
 
-Derived from jhowell's `kfxlib` (bundled in the *KFX Input* Calibre plugin;
-copyright "2016-2025, John Howell"). Update this on every re-sync.
+The derived files come from jhowell's `kfxlib` (bundled in the *KFX Input*
+Calibre plugin; copyright "2016-2025, John Howell"). Update this on every
+re-sync. Per-file copyright headers are authoritative where they disagree with
+this directory-level summary.
 
 | Field | Value |
 |-------|-------|
@@ -101,8 +108,9 @@ git log --diff-filter=AM --pretty='%h %ad %s' --date=short -- plugin/kfxgen/kfxl
 
 ### `standard_symbols.py` is not vendored code
 
-Everything else in this directory is derived from upstream `kfxlib`. That file is
-not, and the distinction is easy to lose because of where it sits.
+Every file here except `standard_symbols.py` and `__init__.py` is derived from
+upstream `kfxlib`. Those two are not, and the distinction is easy to lose
+because of where they sit.
 
 Measured against `kfxlib` 20260520: no upstream module defines these names, no
 `standard_symbols.py` exists upstream at all, and **0 of its 247 symbols** appear

--- a/plugin/kfxgen/kfxlib_minimal/standard_symbols.py
+++ b/plugin/kfxgen/kfxlib_minimal/standard_symbols.py
@@ -1,8 +1,14 @@
-# Part of kfxgen's kfxlib_minimal: a modified subset of Calibre's kfxlib
-# (the KFX plugins by John Howell). See kfxlib_minimal/README.md for the
-# list of local modifications.
+# Original kfxgen work — NOT a subset of Calibre's kfxlib, despite living in
+# this directory. `STANDARD_SYMBOLS` was harvested by decoding Kindle Previewer
+# output; no upstream `kfxlib` module defines these names, and none of the 247
+# appears anywhere in that source. The file sits here because
+# `StandardSymbolTable` subclasses the vendored `LocalSymbolTable`, which places
+# it in the same GPL v3 combined work — subclassing does not transfer authorship.
+#
+# A directory-wide attribution sweep (#4) credited this file to John Howell.
+# That was wrong and is corrected here; see kfxlib_minimal/README.md.
 __license__ = "GPL v3"
-__copyright__ = "2016-2025, John Howell <jhowell@acm.org>"
+__copyright__ = "2025-2026, Justin Loutsch <justin.loutsch@gmail.com>"
 
 from .ion_symbol_table import LocalSymbolTable
 


### PR DESCRIPTION
Found while reviewing this repo against the [Asahi Linux generative-AI policy](https://asahilinux.org/docs/project/policies/slop/), specifically its claim that LLM-assisted work risks using IP without realising it. The audit came back clean — with one exception, and it points the opposite way to what that policy warns about.

## The defect

`plugin/kfxgen/kfxlib_minimal/standard_symbols.py` carried:

```python
# Part of kfxgen's kfxlib_minimal: a modified subset of Calibre's kfxlib
# (the KFX plugins by John Howell). ...
__copyright__ = "2016-2025, John Howell <jhowell@acm.org>"
```

It is not a subset of kfxlib, and it is not jhowell's. It is original kfxgen work credited to someone else.

## Measurement

Against the pinned `kfxlib` 20260520:

- No `standard_symbols.py` exists upstream.
- **0 of its 247 symbols** appear anywhere in upstream source as string literals.
- 0 of 257 code shingles shared.

`STANDARD_SYMBOLS` holds *local* symbol names — content and style names like `c0`, `c1AJ-ad`, `s28K`, `sV5` — harvested by decoding Kindle Previewer output. Same provenance as the rest of kfxgen's format knowledge: observation of Amazon's files, not upstream source.

For contrast, the same scan over every other file:

| File | Shared with upstream |
|---|---|
| `yj_symbol_catalog.py` | 97% |
| `yj_container.py` | 68% |
| `ion_text.py` / `utilities.py` | 43% / 42% |
| `ion_binary.py` / `kfx_container.py` / `ion_symbol_table.py` | 31% / 22% / 21% |
| **`standard_symbols.py`** | **0%** |
| every non-vendored file, incl. `native_generator.py` (2,428 shingles) | 0% |

## How it happened

`b2a1782` (#4) added an identical attribution header to six files in this directory in one pass. Five were genuinely derived. This one was swept in.

## Why bother

Over-crediting creates no legal exposure — GPL v3 either way — but it is wrong, and it blurs the derived/original boundary the rest of the attribution work here is careful about. Someone auditing provenance would conclude the symbol table came from jhowell and draw the wrong conclusion about where kfxgen's format knowledge originates. That matters more than usual for a reverse-engineering project.

`StandardSymbolTable` does subclass the vendored `LocalSymbolTable`, which is why the file lives in that directory — that puts it in the same GPL v3 combined work, already true project-wide, but subclassing does not transfer authorship.

## Changes

- Header names the actual author and explains why the file sits where it does.
- The README modifications table listed `standard_symbols.py` and `yj_symbol_catalog.py` in **one row** as both "populated for native KFX generation", when they have opposite provenance (0% vs 97%). Split, with the measurements stated, plus a section on why the directory is not uniform.
- `NOTICE` claimed every file under `plugin/kfxgen/kfxlib_minimal/` is a modified subset of kfxlib. It now carves out the exception and states per-file headers win on conflict.

## Deliberately not changed

`__init__.py` has no attribution header and keeps none. It makes no false claim, and what it re-exports is upstream's API surface — closer to derived than `standard_symbols.py`, not further.

No code change. 671 tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Nb3ZJwK6EFBGNncx91Db3