### PR TITLE
ci: gate on the byte-identical golden diff

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,24 @@ jobs:
         run: |
           pytest tests/unit tests/integration -v
 
+      # tier3_strict is excluded by pytest.ini's addopts, so the line above
+      # never runs it and never has. It needs its own invocation with an
+      # explicit -m, which overrides that exclusion.
+      #
+      # It was opt-in because the generator used to emit ~240 byte differences
+      # between two runs of the same input, which would have failed every run.
+      # #96 fixed that (image style symbols were allocated from an unordered
+      # set), so the layer now passes in 0.44s and is worth gating on.
+      #
+      # A failure here means the bytes moved. That is either a regression or an
+      # intentional output change that needs its goldens regenerated — see
+      # CONTRIBUTING.md → Updating goldens after an intentional generator
+      # change. Do not regenerate to make this green without confirming the
+      # drift was intended; that is the whole signal.
+      - name: Byte-identical golden diff (tier-3 strict)
+        run: |
+          pytest -m tier3_strict -v
+
   ruff-lint:
     # Enforce ruff for outside contributors who don't have pre-commit
     # installed locally. Scope is whatever ruff.toml configures (currently

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,9 +56,13 @@ jobs:
       # CONTRIBUTING.md → Updating goldens after an intentional generator
       # change. Do not regenerate to make this green without confirming the
       # drift was intended; that is the whole signal.
+      # Scoped to the file rather than bare `-m tier3_strict`. An unscoped run
+      # replaces addopts' whole `-m` expression, losing `not device and not
+      # slow`, and collects all of `testpaths` (686 items, benchmarks included)
+      # to select 9. Naming the file collects 33 and keeps the device filter.
       - name: Byte-identical golden diff (tier-3 strict)
         run: |
-          pytest -m tier3_strict -v
+          pytest tests/integration/test_golden_corpus.py -m "tier3_strict and not device" -v
 
   ruff-lint:
     # Enforce ruff for outside contributors who don't have pre-commit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,11 +106,22 @@ device today." Don't conflate them.
 | Gate | Required tiers | Command |
 |------|---------------|---------|
 | Pre-push (local) | tier1 | `pytest -m tier1` (wired up in issue 56) |
-| CI on PR | tier1 + tier2 + tier3 | `pytest -m "not device"` (already the default in `pytest.ini`) |
+| CI on PR | tier1 + tier2 + tier3 | `pytest tests/unit tests/integration` (the `pytest.ini` default `-m` applies) |
+| CI on PR | tier3_strict | `pytest -m tier3_strict` — a separate step, because `addopts` excludes it |
 | Release tag | + device | Manual device run by maintainer; release notes must reference which devices were tested |
 
 Skipping `device` in CI is intentional — the runner has no Kindle attached.
 Test failures under `device` block release tags but never block PR merges.
+
+`tier3_strict` needs its own invocation for a mechanical reason worth knowing:
+`pytest.ini` puts `-m "not slow and not device and not tier3_strict"` in
+`addopts`, and that applies to every plain `pytest` call. Only an explicit `-m`
+on the command line overrides it. A step that merely adds paths does not.
+
+Note what tier-2 does *not* contribute here. It skips whenever the vendored
+KFX Input zip is absent, which is every CI run — see issue 99. The row above
+lists it because it runs locally when the zip is present, not because CI
+verifies it.
 
 ## Marker conventions
 
@@ -202,13 +213,24 @@ a copyright + repo-bloat non-starter. Synthetic fixtures cover the
 same shapes (`$164`/`$417` cover, `$175`-bearing `$259` image
 entries, multi-section `$265` maps) at ~7 KB each.
 
-**Diff strategy:** structural only (fragment-type counts and per-type
-top-level key sets). The generator currently emits ~240 byte
-differences between two consecutive runs of the same input — a
-SHA-256-byte-identical layer would fail on every test run. Tracked
-as issue 89; once that
-lands, a `tier3_strict` byte-identical layer can be added on top of
-the structural diff.
+**Diff strategy:** two layers.
+
+1. **Structural** (`tier3`) — fragment-type counts and per-type top-level key
+   sets. Runs by default.
+2. **Byte-identical** (`tier3_strict`) — SHA-256 of the whole file against the
+   committed golden. Excluded from `pytest.ini`'s `addopts`, so a plain
+   `pytest` will not run it; CI invokes it explicitly with `-m tier3_strict`.
+
+The strict layer was opt-in because the generator used to emit ~240 byte
+differences between two consecutive runs of the same input, which would have
+failed every run. Issue 96 fixed that — image style symbols were being
+allocated by iterating an unordered set, and CPython randomizes string hashing
+per interpreter. The layer now passes in well under a second and gates every
+PR.
+
+When it fails, the bytes moved. That is either a regression or an intentional
+output change whose goldens need regenerating (see below). Regenerating to make
+CI green without first confirming the drift was intended defeats the gate.
 
 ### Updating goldens after an intentional generator change
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -234,13 +234,17 @@ CI green without first confirming the drift was intended defeats the gate.
 
 ### Updating goldens after an intentional generator change
 
-If your change deliberately alters KFX output, the structural diff
-will fail until you regenerate the goldens:
+If your change deliberately alters KFX output, the goldens must be
+regenerated. Verify **both** layers afterwards — a change that moves bytes
+without moving structure passes `tier3` while the `tier3_strict` step that
+blocks the merge still fails, so checking only the first tells you nothing
+about the gate you are actually up against:
 
 ```bash
 python -m tests.fixtures.golden.regenerate
 git diff --stat tests/fixtures/golden/expected/
 pytest -m tier3
+pytest tests/integration/test_golden_corpus.py -m "tier3_strict and not device"
 git add tests/fixtures/golden/expected/ tests/fixtures/golden/inputs.py
 ```
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -35,7 +35,7 @@ markers =
     tier1: in-process Python invariants (cheapest, runs every PR + pre-push)
     tier2: Calibre kfxlib differential decode (independent provenance, runs every PR)
     tier3: golden-file diff against device-verified corpus (runs every PR)
-    tier3_strict: byte-identical golden diff (opt-in; run with `pytest -m tier3_strict`)
+    tier3_strict: byte-identical golden diff (excluded from addopts; CI runs it as its own step)
     device: requires physical Kindle device (manual, gates release tags only)
     critical: critical tests that must always pass (e.g. KFX fragment presence)
     slow: slow-running tests like corpus validation (skip with: pytest -m "not slow")

--- a/tests/integration/test_golden_corpus.py
+++ b/tests/integration/test_golden_corpus.py
@@ -14,11 +14,13 @@ Two diff layers:
   compare fragment-type multiset and per-fragment-type top-level key
   set. Tolerant of benign byte-level reorderings; fails on shape
   regressions like a missing fragment type or a renamed key.
-- **Byte-identical diff (opt-in, `tier3_strict`)** — SHA-256 the file.
-  Run with `pytest -m tier3_strict`. Verifies that the generator is
-  bit-stable across runs of the same input. Enabled by #89, which
-  replaced the random Container ID + ASIN with content-derived
-  deterministic IDs.
+- **Byte-identical diff (`tier3_strict`)** — SHA-256 the file.
+  Excluded from `pytest.ini`'s `addopts`, so a plain `pytest` skips it;
+  CI runs it as its own step and it gates every PR. Verifies that the
+  generator is bit-stable across runs of the same input. Possible
+  because Container ID and ASIN are derived from book content rather
+  than randomly (`native_generator.py:1964`), and because #96 removed
+  the last source of run-to-run drift.
 
 A third class of test, `test_fixture_exercises_target_shape`, asserts
 that each fixture still emits the structural element it was designed
@@ -176,9 +178,10 @@ def test_golden_byte_identical(name, builder, tmp_path):
     is bit-stable across runs — the strongest "this PR didn't drift
     output" signal available below device verification.
 
-    Enabled by #89 (deterministic Container ID + ASIN). If you bump
-    one of those derivations, expect this test to fail until you
-    regenerate the goldens via `python -m tests.fixtures.golden.regenerate`."""
+    Rests on Container ID and ASIN being content-derived rather than
+    random (`native_generator.py:1964`). If you bump one of those
+    derivations, expect this test to fail until you regenerate the
+    goldens via `python -m tests.fixtures.golden.regenerate`."""
     import hashlib
 
     fresh_bytes = _build_fresh(name, builder, tmp_path)


### PR DESCRIPTION
Found while checking whether the fragment-level conformance oracle from [HankunYu/kindle-comic-workaround-5.19.x](https://github.com/HankunYu/kindle-comic-workaround-5.19.x) is reachable here. That's the separate issue below; this is the free half.

## `tier3_strict` has never run

It exists, it passes, and it gates nothing:

- `pytest.ini:17` — `addopts` carries `-m "not slow and not device and not tier3_strict"`, which applies to every plain `pytest` call
- `test.yml:43` — ran `pytest tests/unit tests/integration -v`, adding paths but no `-m`, so the exclusion stood
- `corpus.yml` — passes `-m slow`, which overrides but does not include it

Only an explicit `-m` on the command line overrides `addopts`, so it needs its own step. Hence a second invocation rather than folding it into the existing one.

## Why it was opt-in, and why that no longer holds

`CONTRIBUTING.md` said:

> The generator currently emits ~240 byte differences between two consecutive runs of the same input — a SHA-256-byte-identical layer would fail on every test run. Tracked as issue 89

That was true and is not any more. #96 found the cause — image style symbols allocated by iterating an unordered set, against CPython's per-interpreter string hash randomization — and fixed it. The strict layer now passes in **0.39s**.

The tracking reference was also wrong: #89 is a merged PR about Previewer drift detection, and no open issue tracks byte-identity at all.

## Verified it can fail

A gate that has never failed is not evidence of anything until you make it fail on purpose:

```
flipped 1 bit at offset 3517 in tests/fixtures/golden/expected/body_images.kfx
→ 1 failed, 8 passed
git checkout -- <golden>
→ 9 passed
```

## Consequence worth accepting deliberately

This now blocks any intentional output change until its goldens are regenerated. That is the point of the gate. The regeneration procedure is already documented; the risk is regenerating reflexively to get CI green, so the new text says not to do that without confirming the drift was intended.

## Also corrected

The gate ladder gained the new step, the mechanical note about `addopts` explaining why it needs one, and an explicit statement that **tier-2 contributes nothing to CI today** — it skips on every run because the vendored zip is absent (#99). The ladder previously listed tier-2 under "CI on PR" without that qualification, which reads as coverage that does not exist.

## Verification

671 tests pass, 9 strict tests pass, `test.yml` validates as YAML and the new step resolves under the `tests` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Nb3ZJwK6EFBGNncx91Db3