### PR TITLE
test: pin the raised-text encoding choice (#123)

### DIFF
--- a/tests/integration/test_golden_corpus.py
+++ b/tests/integration/test_golden_corpus.py
@@ -303,6 +303,28 @@ def test_fixture_sub_super_marks_shape(tmp_path):
     assert shifts["35"] == "0.75", f"superscript font size moved: {shifts['35']}"
     assert shifts["-20"] == "0.75", f"subscript font size moved: {shifts['-20']}"
 
+    # kfxgen encodes raised text with `$31`, a numeric offset. KFX also has
+    # `$44` (`-kfx-baseline-style`), a semantic enum — `$370` super, `$371`
+    # sub — and that is the one Amazon uses. Measured across four books
+    # converted with Kindle Previewer 3.106 and decoded with upstream kfxlib
+    # 20260520, Amazon emitted `$44` every time and `$31` zero times (#123).
+    #
+    # kfxgen's choice is not wrong. #67 closed on a physical sideload
+    # confirming both forms render correctly at these exact values, over the
+    # tag route and the CSS route. Two valid encodings, one of them verified
+    # on hardware.
+    #
+    # Pinned so a switch is deliberate rather than arriving as regenerated
+    # goldens. The assertions above already fail if `$31` disappears entirely;
+    # this catches the hybrid case where both are emitted.
+    semantic = [f for f in by_type(frags, "$157") if val(f).get(IS("$44")) is not None]
+    assert not semantic, (
+        f"{len(semantic)} styles carry $44 baseline-style. That is Amazon's "
+        "idiom and may be the better one, but switching changes what the "
+        "device draws and the current values are the ones #67 verified — so "
+        "it wants a sideload first (#123)."
+    )
+
 
 @pytest.mark.tier3
 @pytest.mark.integration


### PR DESCRIPTION
#123 recorded from one book that kfxgen encodes raised text differently from Amazon. Three more books confirm it. **I did not switch the encoding**, and this PR explains why plus pins the choice.

## Confirmed across four books

Converted with Kindle Previewer 3.106, decoded with upstream `kfxlib` 20260520:

| Book | `$44` baseline-style | `$31` numeric shift |
|---|---|---|
| pg27827 | super ×5 styles, sub ×1 | **none** |
| pg1727 | top ×1 style, used by 187 runs | **none** |
| pg25851 | baseline ×2, super ×1, sub ×1 | **none** |
| pg40739 | (no raised text) | **none** |

Amazon emits the semantic enum every time and the numeric shift never. It also keeps the publisher's font size on those runs — 0.8, 0.936, 0.833333, 0.694444, 0.75, 0.6 — where kfxgen collapses every raised run to a fixed 0.75.

One correction from the first pass: pg1727 has 187 `<sup>` but only *one* `$44` style, which looked like Amazon had ignored them. Styles are shared — that one style is referenced by 187 runs. Counting runs rather than styles was necessary to see it.

## Why I did not switch it

Changing the encoding changes what the device draws, and `CONTRIBUTING.md:284` makes tier-4 validation mandatory for rendering changes.

The current values carry that evidence: **#67 closed on a physical sideload** confirming both forms render correctly at `$31` 35% / −20% with `$16` 0.75, over both the tag route and the CSS route. A replacement would carry none until someone sideloads it.

Two valid encodings, one of them device-verified. That is not a trade to make from a desk — the fact that Amazon prefers `$44` is evidence about Amazon's toolchain, not about whether a Kindle draws kfxgen's output correctly. It already does.

## What this adds

A tier-3 assertion pinning the choice, so switching has to be deliberate. Without it, a switch moves golden bytes, gets regenerated as an "intentional change", and passes.

Verified non-vacuous by simulating the exact change #123 proposes — repointing both `$31` emission sites at `$44` fails the assertion.

704 tests pass. One file, 48 lines, no production code touched.

## What would close #123 properly

A device comparison: the same book built both ways, sideloaded, and read. That needs an opt-in `$44` code path to generate the comparison file — worth building **if** you want to run it, and not worth carrying otherwise. Say the word and I will add it behind an env flag defaulting to current behaviour.

The font-size half is separable and arguably the more interesting one: kfxgen discarding publisher sizing is a fidelity loss on every `<sup>` and `<sub>` in every book, independent of which shift mechanism is used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Nb3ZJwK6EFBGNncx91Db3