### PR TITLE
feat: opt-in $44 baseline-style encoding for the #123 device comparison

### DIFF
--- a/plugin/kfxgen/native_generator.py
+++ b/plugin/kfxgen/native_generator.py
@@ -55,6 +55,31 @@ SUBSCRIPT_FONT_SIZE = 0.75
 SUBSCRIPT_SHIFT_PCT = -20  # -20% (device-verified, #67)
 
 
+#: Opt-in encoding for raised text, for the device comparison #123 needs.
+#:
+#: EXPERIMENTAL AND TEMPORARY. It exists so the two encodings can be built from
+#: the same source and read side by side on hardware; once that comparison
+#: settles which one kfxgen should emit, this switch and the branch it feeds
+#: should be deleted rather than left as a permanent second code path.
+RAISED_TEXT_ENCODING_ENV = "KFXGEN_RAISED_TEXT_ENCODING"
+
+
+def _use_baseline_style():
+    """True when raised text should use `$44` baseline-style instead of `$31`.
+
+    Amazon emits `$44` (`$370` super, `$371` sub) and never `$31` — measured
+    over four books via Kindle Previewer 3.106 (#123). kfxgen emits `$31`, and
+    that form is device-verified (#67), so the default does not move. What is
+    unknown is whether `$44` renders *as well or better*, and nothing but a
+    sideload answers it.
+    """
+    return os.environ.get(RAISED_TEXT_ENCODING_ENV, "").strip().lower() in {
+        "baseline-style",
+        "baseline_style",
+        "44",
+    }
+
+
 def _env_number(name, default):
     """Read a numeric env override, falling back to `default` when unset or
     unparseable. Resolved per call, not at import, so a conversion can be run
@@ -1343,12 +1368,21 @@ class NativeKFXGenerator:
         # {$16: 0.75rem, $42: ~1.33, $31: <shift>} — superscript is a reduced
         # font-size plus a positive shift, not a dedicated flag. (#52)
         if baseline_shift is not None:
-            value[IS("$31")] = IonStruct(
-                IS("$307"),
-                IonDecimal(baseline_shift[0]),
-                IS("$306"),
-                IS(baseline_shift[1]),
-            )
+            if _use_baseline_style():
+                # Amazon's idiom: state the intent and let the reader compute
+                # the offset. Direction comes from the sign of the shift this
+                # would otherwise have emitted, so both routes (tag and CSS)
+                # and both env overrides keep working unchanged. See #123 —
+                # opt-in only, and only so the two can be compared on device.
+                is_super = not str(baseline_shift[0]).lstrip().startswith("-")
+                value[IS("$44")] = IS("$370" if is_super else "$371")
+            else:
+                value[IS("$31")] = IonStruct(
+                    IS("$307"),
+                    IonDecimal(baseline_shift[0]),
+                    IS("$306"),
+                    IS(baseline_shift[1]),
+                )
 
         return YJFragment(fid=IS(entity_name), ftype=IS("$157"), value=value)
 

--- a/tests/unit/test_native_generator.py
+++ b/tests/unit/test_native_generator.py
@@ -2488,3 +2488,73 @@ def test_sub_and_super_defaults_are_both_device_verified_values():
 
     assert ng.superscript_metrics() == (0.75, ("35", "$314"))
     assert ng.subscript_metrics() == (0.75, ("-20", "$314"))
+
+
+# ── #123: opt-in $44 baseline-style encoding ─────────────────────────────────
+#
+# Amazon emits $44 ($370 super, $371 sub) and never $31, measured over four
+# books. kfxgen emits $31, which is device-verified (#67). Which renders better
+# is unknown and only a sideload answers it, so this exists to build the two
+# forms from one source and compare them on hardware — not as a preference.
+
+
+@pytest.mark.unit
+def test_raised_text_defaults_to_numeric_shift():
+    """Absent the flag, nothing moves. This is the device-verified form."""
+    from kfxgen import native_generator as ng
+
+    assert not ng._use_baseline_style()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "value", ["baseline-style", "baseline_style", "44", "BASELINE-STYLE", " 44 "]
+)
+def test_baseline_style_flag_accepted_forms(monkeypatch, value):
+    from kfxgen import native_generator as ng
+
+    monkeypatch.setenv(ng.RAISED_TEXT_ENCODING_ENV, value)
+    assert ng._use_baseline_style()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("value", ["", "shift", "31", "yes", "true", "1"])
+def test_unrecognised_values_keep_the_default(monkeypatch, value):
+    """Fails closed. A typo or a generic truthy value must not silently switch
+    the encoding to the unverified one."""
+    from kfxgen import native_generator as ng
+
+    monkeypatch.setenv(ng.RAISED_TEXT_ENCODING_ENV, value)
+    assert not ng._use_baseline_style()
+
+
+@pytest.mark.unit
+def test_baseline_style_emits_44_with_correct_direction(monkeypatch):
+    """Direction is derived from the sign of the shift, so both the tag and CSS
+    routes and both font-size overrides keep working unchanged."""
+    from kfxgen.kfxlib_minimal.ion import IS
+
+    from kfxgen import native_generator as ng
+
+    monkeypatch.setenv(ng.RAISED_TEXT_ENCODING_ENV, "baseline-style")
+    gen = ng.NativeKFXGenerator()
+
+    sup = gen.build_fragment_157("s_sup", baseline_shift=("35", "$314"))
+    sub = gen.build_fragment_157("s_sub", baseline_shift=("-20", "$314"))
+
+    assert sup.value.get(IS("$44")) == IS("$370"), "positive shift must be super"
+    assert sub.value.get(IS("$44")) == IS("$371"), "negative shift must be sub"
+    assert sup.value.get(IS("$31")) is None, "must not emit both encodings"
+    assert sub.value.get(IS("$31")) is None, "must not emit both encodings"
+
+
+@pytest.mark.unit
+def test_default_still_emits_31_and_not_44():
+    from kfxgen.kfxlib_minimal.ion import IS
+
+    from kfxgen import native_generator as ng
+
+    gen = ng.NativeKFXGenerator()
+    frag = gen.build_fragment_157("s_sup", baseline_shift=("35", "$314"))
+    assert frag.value.get(IS("$31")) is not None
+    assert frag.value.get(IS("$44")) is None


### PR DESCRIPTION
Builds on #124 (which pins the current choice). This makes the comparison #123 needs actually runnable.

## Why an opt-in rather than a switch

#123 established that Amazon encodes raised text with `$44` baseline-style and never with `$31`, measured over four books. kfxgen emits `$31`, which #67 verified on hardware.

What is unknown is whether `$44` renders **as well or better**. Amazon preferring it is evidence about Amazon's toolchain, not about whether a Kindle draws kfxgen's output correctly — and the device already said it does. Switching blind trades a verified encoding for an unverified one on a conformance argument.

So: build both from one source, read them side by side, then decide.

## The switch

`KFXGEN_RAISED_TEXT_ENCODING=baseline-style` emits `$44` (`$370` super, `$371` sub). Anything else keeps `$31`. Default unchanged, no golden moved, `tier3_strict` clean.

Direction comes from the sign of the shift that would otherwise have been emitted, so both source routes (`<sup>`/`<sub>` tags and CSS `vertical-align`) and both font-size overrides keep working with no second code path.

**Fails closed.** `1`, `true`, `yes`, `shift` all keep the default — only the explicit `baseline-style` / `baseline_style` / `44` switches it. A typo or a generic truthy value must not silently select the unverified encoding.

## This is meant to be deleted

An experiment with an exit condition, marked as such at the constant: once the sideload says which encoding kfxgen should emit, the switch and its branch go. It should not linger as a permanent second path — that is exactly the "experimental code paths left in production" shape.

## Tests

Both paths, 13 cases: default emits `$31` and no `$44`; the flag emits `$44` with correct direction and never both; five unrecognised values pinned to the default.

## Comparison artifacts

Built on the maintainer's Desktop from one source in both encodings:

```
ZZ-123-supsub-A-shift-current.kfx        (current, $31 ×2)
ZZ-123-supsub-B-baselinestyle-123.kfx    (proposed, $44 = $370/$371)
```

Purpose-made rather than a corpus book. pg25851's 18 raised runs are all asterisks — hard to judge a few percent of baseline shift by. This one has `E = mc²`, `H₂O`, `CO₂`, ordinals (1ˢᵗ, 2ⁿᵈ), indices, and a mixed `x₁² + x₂² = r²`, plus a "normal text → H₂O → normal" line as a baseline reference.

Verified the two differ only in encoding: A has 2 `$31` styles and no `$44`; B has `['$370', '$371']` and no `$31`.

Sideloading both and comparing is what closes #123. Worth doing on the Paperwhite (5.19.2) as well as the Oasis, since that also exercises current firmware — see #109.

703 existing tests plus 13 new pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Nb3ZJwK6EFBGNncx91Db3