### PR TITLE
feat: give the tier-4 device gate content and a per-change record (#109)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,44 @@
+<!--
+Delete any section that does not apply. The device block is the one worth not
+deleting reflexively — see CONTRIBUTING.md "Tier 4: device verification".
+-->
+
+## What this changes
+
+<!-- The defect or the behaviour, not the diff. -->
+
+## Why
+
+<!-- What goes wrong without it. Link the issue. -->
+
+## Verification
+
+<!--
+Which tiers actually ran, and what would have failed if the change were wrong.
+"Tests pass" is not evidence a test can discriminate — say what you mutated to
+check it fails.
+-->
+
+- [ ] tier 1–3 pass (`pytest`)
+- [ ] `pytest -m tier3_strict` pass, or goldens intentionally regenerated and the shape change explained above
+- [ ] corpus sweep, if the change touches conversion (`KFXGEN_CORPUS_DIR=… pytest -m slow -k corpus`)
+
+## Device verification (tier 4)
+
+CONTRIBUTING makes this **mandatory before merging** for anything touching
+`$259`, `$260`, `$264`, `$265`, `$550`, or `$164`/`$417` — the fragments whose
+breakage no structural test can see.
+
+- [ ] Not applicable — this change cannot affect rendering
+- [ ] Verified on hardware, and the commit carries a `Device-verified:` trailer
+
+If verified, paste the sign-off table
+(`python scripts/device_signoff.py --summary signoff.json`):
+
+<!--
+| Device | Firmware | Status | Check | Result |
+|---|---|---|---|---|
+-->
+
+If not applicable, say why in one line. A device claim with no model and no
+firmware is not a record (#109).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ Tag every test with the tier of oracle it relies on, so reviewers can tell
 | 1 | `tier1` | In-process Python invariants (entity-id uniqueness, position-map subset relations, fragment-graph consistency — encoded in `tests/unit/test_kfx_invariants.py` and `tests/unit/test_position_map.py`) | < 1 s | Pre-push hook + every PR |
 | 2 | `tier2` | Calibre `kfxlib` differential decode (round-trips our output through an independent decoder) | seconds | Every PR |
 | 3 | `tier3` | Golden-file diff against synthetic regression corpus under `tests/fixtures/golden/expected/` (see [Golden corpus](#golden-corpus) below) | seconds | Every PR |
-| 4 | `device` | Manual verification on a physical Kindle (Paperwhite/Oasis/Voyage) | minutes, manual | Release tags only |
+| 4 | `device` | Manual verification on the physical Kindles listed under [Tier 4](#tier-4-device-verification) | minutes, manual | Release tags only |
 
 A tier-1 pass means "kfxgen is internally consistent." A tier-2 pass means
 "another implementation can decode it." A tier-3 pass means "it matches a
@@ -112,6 +112,65 @@ device today." Don't conflate them.
 
 Skipping `device` in CI is intentional — the runner has no Kindle attached.
 Test failures under `device` block release tags but never block PR merges.
+
+### Tier 4: device verification
+
+The hardware, pinned. "A physical Kindle" is not a record — `Paperwhite` alone
+spans several revisions whose behaviour differs (the CHANGELOG thumbnail table
+has a Voyage failing where a Paperwhite succeeds), so generation and firmware
+both get written down (#109).
+
+| Device | Firmware | Status |
+|---|---|---|
+| Oasis, 10th generation (2019) | 5.18.2 | Terminal — no further updates |
+| Paperwhite, 11th generation (2021) | 5.19.2 | Current for that model |
+
+Test both, and understand what each buys. The Oasis can never leave 5.18.2, so
+it stands for every reader who will never update — a permanent population, and
+for a change that removes a fallback it is the *stricter* test (#126 dropped
+`$31` with no fallback, which would have degraded silently there). The
+Paperwhite is on current firmware and is the only one of the two that can
+observe render-side drift as Amazon moves. A pass on one is real evidence; it
+is not the same claim as a pass on both.
+
+Run the checklist:
+
+```bash
+pytest -m device                       # prints the procedures, fails unrun
+python scripts/device_signoff.py --template > signoff.json
+# ... perform the checks, fill in outcomes and the Paperwhite's firmware ...
+KFXGEN_DEVICE_SIGNOFF=signoff.json pytest -m device
+python scripts/device_signoff.py --summary signoff.json   # release-notes table
+```
+
+These tests **fail** rather than skip when nothing has been signed off. A skip
+is how a gate goes quiet: #99 is tier 2 skipping on every PR since it was
+added, and #92, #98 and #106 are the same shape. Before #109 the `device`
+marker was carried by no test at all, so `pytest -m device` collected nothing
+— exit 5, "no tests collected". That is a failure code rather than a false
+pass, but it reports the absence of tests, never the absence of testing, and
+it tells a reader nothing about what should have been checked.
+
+### Recording a device pass
+
+Put a trailer on the commit, one line per device, so `git log` can answer "was
+this change checked on hardware?":
+
+```
+Device-verified: Oasis 10th gen (2019), firmware 5.18.2 — TOC taps, return links
+Device-verified: Paperwhite 11th gen (2021), firmware 5.19.2 — TOC taps, return links
+```
+
+Firmware is a constant for the Oasis and a per-run value for the Paperwhite.
+List them over a range with:
+
+```bash
+python scripts/device_signoff.py --trailers v5.7.2..HEAD
+```
+
+The trailer is the per-change record; the CHANGELOG entry is the per-release
+one. Both are wanted — the CHANGELOG says the release was verified, the trailer
+says which change was.
 
 `tier3_strict` needs its own invocation for a mechanical reason worth knowing:
 `pytest.ini` puts `-m "not slow and not device and not tier3_strict"` in
@@ -143,8 +202,10 @@ def test_kfxlib_round_trip():
 def test_matches_corpus_baseline():
     ...
 
+# Tier 4 is a checklist a human performs; add entries to
+# tests/device/checklist.py rather than writing a new test function.
 @pytest.mark.device
-def test_nav_pane_renders_on_paperwhite():
+def test_device_check_signed_off(check, signoff):
     ...
 ```
 
@@ -284,6 +345,11 @@ If you change anything that touches `$259`, `$260`, `$264`, `$265`, `$550`, or
 `$164`/`$417`, real-device validation (tier 4) is mandatory before merging.
 Tier-1 invariant tests (issue 43) encode many of these rules, but not all of
 them — when in doubt, test on device.
+
+Mandatory means the PR carries the evidence: run the checklist, and put a
+`Device-verified:` trailer on the commit naming model, firmware and what was
+checked. See [Tier 4](#tier-4-device-verification). Without it the claim is
+unanswerable a month later, which is what #109 was opened about.
 
 ## Public-domain corpus sweep
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -36,7 +36,9 @@ markers =
     tier2: Calibre kfxlib differential decode (independent provenance, runs every PR)
     tier3: golden-file diff against device-verified corpus (runs every PR)
     tier3_strict: byte-identical golden diff (excluded from addopts; CI runs it as its own step)
-    device: requires physical Kindle device (manual, gates release tags only)
+    device: requires physical Kindle device (manual, gates release tags only);
+        the checklist lives in tests/device/ and FAILS rather than skips when
+        nothing is signed off, so the tier reports what was not checked (#109)
     critical: critical tests that must always pass (e.g. KFX fragment presence)
     slow: slow-running tests like corpus validation (skip with: pytest -m "not slow")
     unit: unit tests (fast, isolated)

--- a/scripts/device_signoff.py
+++ b/scripts/device_signoff.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Tier-4 sign-off: generate a template, summarise a result, or audit history.
+
+Tier 4 is the only oracle that proves a KFX renders, and #109 is about it
+leaving no per-change record. This script is the writing end of that record;
+`pytest -m device` is the reading end.
+
+    python scripts/device_signoff.py --template > signoff.json
+    KFXGEN_DEVICE_SIGNOFF=signoff.json pytest -m device
+    python scripts/device_signoff.py --summary signoff.json
+    python scripts/device_signoff.py --trailers v5.7.2..HEAD
+
+`--summary` prints the block to paste into release notes or a PR, in the form
+CONTRIBUTING asks for: model, generation, firmware, and what was checked.
+
+`--trailers` answers the question #109 says is currently unanswerable — "was
+this change device-checked?" — by listing `Device-verified:` trailers over a
+commit range.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tests.device.checklist import (  # noqa: E402
+    CHECKS,
+    DEVICES,
+    results_for,
+    validate_result,
+)
+
+TRAILER = "Device-verified"
+
+
+def _current_build() -> str:
+    try:
+        sha = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        return sha
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return ""
+
+
+def template() -> dict:
+    """A sign-off with every check and device present and nothing invented.
+
+    Pre-filled with the firmware of the terminal device, because that cannot
+    move and re-typing a constant is how transcription errors get in. The
+    Paperwhite's is left blank on purpose — it can change, so it has to be read
+    off the device each run.
+    """
+    results = []
+    for check in CHECKS:
+        for device_id, device in sorted(DEVICES.items()):
+            results.append(
+                {
+                    "check": check.id,
+                    "device": device_id,
+                    "firmware": device.firmware or "",
+                    "outcome": "",
+                    "note": "",
+                }
+            )
+    return {
+        "build": _current_build(),
+        "book": "",
+        "results": results,
+    }
+
+
+def summarise(path: Path) -> int:
+    signoff = json.loads(path.read_text())
+    problems = []
+    for result in signoff.get("results") or []:
+        problems += [f"{result}: {p}" for p in validate_result(result)]
+
+    print(f"Device sign-off — build {signoff.get('build') or '<unrecorded>'}")
+    if signoff.get("book"):
+        print(f"Book: {signoff['book']}")
+    print()
+    print("| Device | Firmware | Status | Check | Result |")
+    print("|---|---|---|---|---|")
+    for check in CHECKS:
+        for result in results_for(signoff, check.id):
+            device = DEVICES.get(result.get("device"))
+            if device is None:
+                continue
+            status = "terminal" if device.terminal else "current"
+            outcome = result.get("outcome") or "—"
+            note = result.get("note") or ""
+            cell = f"{outcome}{' — ' + note if note else ''}"
+            print(
+                f"| {device.model} {device.generation} | "
+                f"{result.get('firmware', '')} | {status} | {check.title} | {cell} |"
+            )
+
+    if problems:
+        print("\nProblems:", file=sys.stderr)
+        for p in problems:
+            print(f"  {p}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def trailers(rev_range: str) -> int:
+    """List `Device-verified:` trailers over a commit range.
+
+    Prints commits that carry one and, separately, the count that do not — the
+    absence is the interesting half, and a report that only showed hits would
+    read as coverage.
+    """
+    out = subprocess.run(
+        ["git", "log", "--format=%H%x1f%s%x1f%b%x1e", rev_range],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    verified, plain = [], 0
+    for record in out.split("\x1e"):
+        record = record.strip("\n")
+        if not record:
+            continue
+        sha, subject, body = (record.split("\x1f") + ["", ""])[:3]
+        lines = [ln.strip() for ln in body.splitlines() if ln.startswith(TRAILER)]
+        if lines:
+            verified.append((sha[:9], subject, lines))
+        else:
+            plain += 1
+
+    for sha, subject, lines in verified:
+        print(f"{sha}  {subject}")
+        for line in lines:
+            print(f"           {line}")
+    print(f"\n{len(verified)} commit(s) carry a {TRAILER} trailer; {plain} do not.")
+    if not verified:
+        print(
+            f"No {TRAILER} trailers in {rev_range}. That is not a failure — most "
+            "changes do not need hardware — but it does mean nothing in this "
+            "range is answerable as device-checked.",
+            file=sys.stderr,
+        )
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument(
+        "--template",
+        action="store_true",
+        help="print a blank sign-off covering every check and device",
+    )
+    g.add_argument(
+        "--summary", metavar="FILE", help="print a sign-off as a release-notes table"
+    )
+    g.add_argument(
+        "--trailers",
+        metavar="RANGE",
+        help="list Device-verified trailers over a commit range",
+    )
+    g.add_argument(
+        "--checklist",
+        action="store_true",
+        help="print the procedures without running pytest",
+    )
+    args = ap.parse_args()
+
+    if args.template:
+        print(json.dumps(template(), indent=2))
+        return 0
+    if args.summary:
+        return summarise(Path(args.summary))
+    if args.trailers:
+        return trailers(args.trailers)
+    if args.checklist:
+        for device in DEVICES.values():
+            print(f"  device: {device.label}{' (terminal)' if device.terminal else ''}")
+        print()
+        from tests.device.checklist import procedure_text
+
+        for check in CHECKS:
+            print(procedure_text(check))
+            print()
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/device/checklist.py
+++ b/tests/device/checklist.py
@@ -1,0 +1,256 @@
+"""The tier-4 checklist: what a human performs on hardware, and the record it
+leaves behind (#109).
+
+Tier 4 is the only oracle in this repo that proves a KFX *renders*. It was also
+the only tier with nothing mechanical behind it — the `device` marker was
+declared, documented, and carried by no test, so `pytest -m device` collected
+nothing (exit 5, "no tests collected") and said nothing about what should have
+been checked. This module gives the tier something to collect, and gives a
+device pass a shape that survives being asked about later.
+
+Two things are recorded, because either alone is unreadable a year on:
+
+* **What was checked** — a named procedure with the issues it stands for, so
+  "device-verified" means a specific thing rather than a feeling.
+* **What it ran on** — model, generation and firmware. #109's own argument is
+  that "a physical Kindle" is not a record: "Paperwhite" spans several
+  revisions whose behaviour differs (the CHANGELOG thumbnail table has a Voyage
+  failing where a Paperwhite succeeds), so the generation decides the outcome.
+
+The pair of devices matters as much as either one. The Oasis is on terminal
+firmware and can never move, so it stands for every reader that will never
+update — a permanent population, and for some changes the *stricter* test
+(#126 removed `$31` with no fallback, which would have degraded silently
+there). The Paperwhite is on current firmware and is the only one of the two
+that can observe render-side drift as Amazon changes things. A pass on one is
+worth recording; it just is not the same claim as a pass on both.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+
+#: Environment variable naming the sign-off file. Absent means "not verified",
+#: which is a failure for a release gate rather than something to skip past.
+SIGNOFF_ENV = "KFXGEN_DEVICE_SIGNOFF"
+
+VALID_OUTCOMES = ("pass", "fail")
+
+
+@dataclass(frozen=True)
+class Device:
+    """One piece of tier-4 hardware.
+
+    `terminal` means the model no longer receives firmware updates, so its
+    firmware is a property of the device rather than of the run and is pinned
+    here. A non-terminal device's firmware can move under us, so it has to be
+    recorded per run.
+    """
+
+    id: str
+    model: str
+    generation: str
+    firmware: str | None
+    terminal: bool
+
+    @property
+    def label(self) -> str:
+        fw = self.firmware or "<firmware recorded per run>"
+        return f"{self.model} {self.generation}, firmware {fw}"
+
+
+#: The repo's tier-4 hardware, pinned in #109 after the model generations were
+#: read off Settings -> Device Options -> Device Info.
+DEVICES: dict[str, Device] = {
+    "oasis-10": Device(
+        id="oasis-10",
+        model="Oasis",
+        generation="10th gen (2019)",
+        firmware="5.18.2",
+        terminal=True,
+    ),
+    "paperwhite-11": Device(
+        id="paperwhite-11",
+        model="Paperwhite",
+        generation="11th gen (2021)",
+        firmware=None,
+        terminal=False,
+    ),
+}
+
+
+@dataclass(frozen=True)
+class Check:
+    """One thing a human does on the device, and why it is worth doing."""
+
+    id: str
+    title: str
+    issues: tuple[str, ...]
+    procedure: str
+    fails_like: str = ""
+    tags: tuple[str, ...] = field(default_factory=tuple)
+
+
+#: Each entry earns its place by standing for a defect that actually shipped.
+#: `tags` mark the change classes CONTRIBUTING calls out as needing tier 4
+#: before merge, so a PR touching them can name the checks it needs.
+CHECKS: tuple[Check, ...] = (
+    Check(
+        id="toc_navigation",
+        title="Navigation pane entries land on their chapter",
+        issues=("#51", "#62"),
+        procedure=(
+            "Open Go To -> Table of Contents. Tap three entries spread through "
+            "the book, including the last one. Each must land at the start of "
+            "the chapter it names."
+        ),
+        fails_like=(
+            "An entry does nothing, or lands at the top of the book. Every "
+            "link kfxgen emitted once resolved against nothing (#51) and "
+            "structural tests could not see it."
+        ),
+        tags=("nav",),
+    ),
+    Check(
+        id="note_round_trip",
+        title="A note marker and its return link both land on the marker",
+        issues=("#52", "#79"),
+        procedure=(
+            "Find a superscript note marker in the body. Tap it: it must land "
+            "on the note. Tap the note's return link: it must land back on the "
+            "marker, not at the top of the paragraph holding it."
+        ),
+        fails_like=(
+            "The return link lands a paragraph early. Anchors are "
+            "paragraph-granular, so landing more than a page off means a "
+            "stale sideload or a genuine regression (#79)."
+        ),
+        tags=("nav",),
+    ),
+    Check(
+        id="body_images_render",
+        title="Every image the source displays is drawn",
+        issues=("#102", "#116"),
+        procedure=(
+            "Page through a chapter with captioned figures. Every figure must "
+            "draw, not merely occupy space. Check a figure that sits between "
+            "two paragraphs and one directly under a heading."
+        ),
+        fails_like=(
+            "Images are present in the container but nothing is drawn — #102 "
+            "shipped with every image in the file and none on screen, which "
+            "counting resources cannot distinguish."
+        ),
+        tags=("$164", "$417", "images"),
+    ),
+    Check(
+        id="raised_text",
+        title="Superscript and subscript render raised and smaller",
+        issues=("#115", "#123", "#126"),
+        procedure=(
+            "Find a superscript note marker and a subscript (a chemical "
+            "formula or footnote index). Both must sit off the baseline and "
+            "render smaller than surrounding text."
+        ),
+        fails_like=(
+            "Text renders at full size on the baseline. #126 removed `$31` "
+            "with no fallback, so a reader ignoring `$44` degrades silently — "
+            "the terminal-firmware device is the stricter test here."
+        ),
+        tags=("style",),
+    ),
+    Check(
+        id="contents_page",
+        title="The contents page is generated, singular, and free of raw tokens",
+        issues=("#132", "#133", "#135"),
+        procedure=(
+            "Open the generated contents page. It must list real chapter "
+            "titles, with no image entry and no stray control characters. The "
+            "book's own listing must not also appear in the body. Then page "
+            "through the opening pages of the book from the very start."
+        ),
+        fails_like=(
+            "An unresolved image token reaches the container as raw control "
+            "bytes. On a Paperwhite this crashed the reader while paging the "
+            "opening pages, so this check is a crash gate, not a cosmetic one "
+            "(#133)."
+        ),
+        tags=("contents", "$164"),
+    ),
+    Check(
+        id="cover_thumbnail",
+        title="The cover appears as the home-screen thumbnail",
+        issues=("#39",),
+        procedure=(
+            "Return to the home screen. The book must show its cover, not a "
+            "generic placeholder or the title on a grey tile."
+        ),
+        fails_like=(
+            "A short ASIN prefix inhibited thumbnail extraction (#39); the "
+            "container looks correct either way."
+        ),
+        tags=("cover", "$164"),
+    ),
+)
+
+
+def check_by_id(check_id: str) -> Check | None:
+    for check in CHECKS:
+        if check.id == check_id:
+            return check
+    return None
+
+
+def validate_result(result: dict) -> list[str]:
+    """Problems with one sign-off entry. Empty list means it counts as evidence.
+
+    Rejecting rather than ignoring a malformed entry is the point: a record
+    that quietly drops what it cannot parse is back to being unanswerable.
+    """
+    problems: list[str] = []
+
+    check_id = result.get("check")
+    if check_by_id(check_id) is None:
+        problems.append(f"unknown check {check_id!r}")
+
+    device_id = result.get("device")
+    device = DEVICES.get(device_id)
+    if device is None:
+        problems.append(f"unknown device {device_id!r}")
+
+    firmware = (result.get("firmware") or "").strip()
+    if not firmware:
+        problems.append("firmware not recorded")
+    elif device is not None and device.terminal and firmware != device.firmware:
+        problems.append(
+            f"{device.id} is on terminal firmware {device.firmware}; "
+            f"sign-off claims {firmware!r}"
+        )
+
+    outcome = result.get("outcome")
+    if outcome not in VALID_OUTCOMES:
+        problems.append(f"outcome must be one of {VALID_OUTCOMES}, got {outcome!r}")
+
+    return problems
+
+
+def results_for(signoff: dict, check_id: str) -> list[dict]:
+    """Entries in a loaded sign-off that refer to `check_id`."""
+    return [r for r in (signoff.get("results") or []) if r.get("check") == check_id]
+
+
+def signoff_path() -> str | None:
+    return os.environ.get(SIGNOFF_ENV) or None
+
+
+def procedure_text(check: Check) -> str:
+    """The checklist entry as a human reads it in a failure message."""
+    lines = [
+        f"{check.title}  [{check.id}]",
+        f"  stands for: {', '.join(check.issues)}",
+        f"  do: {check.procedure}",
+    ]
+    if check.fails_like:
+        lines.append(f"  fails like: {check.fails_like}")
+    return "\n".join(lines)

--- a/tests/device/test_device_checklist.py
+++ b/tests/device/test_device_checklist.py
@@ -1,0 +1,129 @@
+"""Tier 4: the checks a human performs on hardware (#109).
+
+Excluded from every default run by `pytest.ini`'s `addopts`, so this costs a
+normal `pytest` invocation nothing. Run it deliberately:
+
+    pytest -m device                      # prints the checklist, fails unrun
+    KFXGEN_DEVICE_SIGNOFF=signoff.json pytest -m device
+
+These **fail** rather than skip when there is no sign-off. A skip is how a
+gate goes quiet — #99 is tier 2 skipping on every PR since it was added, and
+#92, #98 and #106 are the same shape. A release gate that reports "nothing to
+do" when nobody has touched a Kindle is worse than one that reports nothing at
+all, because it looks like a pass.
+
+Generate a template to fill in with:
+
+    python scripts/device_signoff.py --template > signoff.json
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from tests.device.checklist import (
+    CHECKS,
+    DEVICES,
+    SIGNOFF_ENV,
+    procedure_text,
+    results_for,
+    signoff_path,
+    validate_result,
+)
+
+pytestmark = pytest.mark.device
+
+
+def _load_signoff():
+    path = signoff_path()
+    if not path:
+        return None
+    p = Path(path)
+    if not p.is_file():
+        pytest.fail(
+            f"{SIGNOFF_ENV} points at {path!r}, which does not exist. "
+            "Generate one with: python scripts/device_signoff.py --template"
+        )
+    try:
+        return json.loads(p.read_text())
+    except json.JSONDecodeError as exc:
+        pytest.fail(f"{path} is not valid JSON: {exc}")
+
+
+@pytest.fixture(scope="session")
+def signoff():
+    return _load_signoff()
+
+
+@pytest.mark.parametrize("check", CHECKS, ids=lambda c: c.id)
+def test_device_check_signed_off(check, signoff):
+    """One checklist entry. Fails with the procedure when it has not been run.
+
+    The failure message *is* the checklist — running `pytest -m device` with no
+    sign-off prints exactly what to do on the device, which is why these are
+    tests rather than a document nobody opens.
+    """
+    if signoff is None:
+        pytest.fail(
+            "No device sign-off recorded.\n\n"
+            f"{procedure_text(check)}\n\n"
+            f"Record the result and re-run with {SIGNOFF_ENV}=<file>. "
+            "Template: python scripts/device_signoff.py --template"
+        )
+
+    results = results_for(signoff, check.id)
+    if not results:
+        pytest.fail(f"No result recorded for this check.\n\n{procedure_text(check)}")
+
+    problems = []
+    for result in results:
+        problems += [f"{result!r}: {p}" for p in validate_result(result)]
+    assert not problems, (
+        "Sign-off entries are not usable as evidence:\n  " + "\n  ".join(problems)
+    )
+
+    failed = [r for r in results if r.get("outcome") == "fail"]
+    assert not failed, f"{check.title} failed on hardware:\n  " + "\n  ".join(
+        f"{r['device']} (fw {r['firmware']}): {r.get('note', '')}" for r in failed
+    )
+
+
+def test_both_devices_were_exercised(signoff):
+    """A pass on one device is evidence; it is not the same claim as a pass on
+    both, and the record should not let the two blur.
+
+    The Oasis is on terminal firmware: it stands for every reader that will
+    never update, and for changes that remove a fallback it is the stricter
+    test (#126). The Paperwhite is on current firmware and is the only one that
+    can see render-side drift as Amazon moves. Neither substitutes for the
+    other.
+    """
+    if signoff is None:
+        pytest.fail(
+            "No device sign-off recorded, so no device was exercised. "
+            f"Set {SIGNOFF_ENV}=<file>."
+        )
+
+    seen = {r.get("device") for r in (signoff.get("results") or [])}
+    missing = sorted(set(DEVICES) - seen)
+    assert not missing, (
+        "Only part of the tier-4 hardware was exercised. Missing: "
+        + ", ".join(f"{d} ({DEVICES[d].label})" for d in missing)
+        + ".\nRecord a result for both, or state in the release notes which "
+        "device the claim rests on."
+    )
+
+
+def test_signoff_names_the_build_it_covers(signoff):
+    """A result with no build attached is the version-granularity problem #109
+    describes: it says the project was checked, not that *this change* was."""
+    if signoff is None:
+        pytest.fail(f"No device sign-off recorded. Set {SIGNOFF_ENV}=<file>.")
+    build = (signoff.get("build") or "").strip()
+    assert build, (
+        "Sign-off does not name the build it covers. Record the commit sha or "
+        "version, so 'was this change device-checked?' is answerable later."
+    )

--- a/tests/unit/test_device_gate.py
+++ b/tests/unit/test_device_gate.py
@@ -1,0 +1,177 @@
+"""Guards on the tier-4 device gate itself (#109).
+
+Tier 4 is the only oracle that proves a KFX renders, and it was the one tier
+with nothing mechanical behind it: `pytest.ini` declared the `device` marker,
+`CONTRIBUTING.md` documented it as the example to copy, and *no test carried
+it*.
+
+#109 describes that as exiting 0 and reading as a pass. Measured, it is
+narrower than that: `pytest -m device` with nothing to collect exits 5, which
+is a failure code. The real gap is that the tier had no *content* — no
+procedure to perform, no record to leave, and nothing that distinguishes "no
+tests exist" from "here is what should have been checked and was not". An
+empty selection reports the absence of tests, never the absence of testing.
+
+These tests run in tier 1, on every PR, and fail if that state returns.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.device.checklist import (
+    CHECKS,
+    DEVICES,
+    check_by_id,
+    results_for,
+    validate_result,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@pytest.mark.tier1
+@pytest.mark.unit
+def test_device_marker_collects_at_least_one_test():
+    """`pytest -m device` must not be a no-op.
+
+    Runs the real collection rather than grepping for the decorator, because
+    the thing being guarded is the command's behaviour: an empty selection
+    exits 0 and reports success, which is exactly how the gate went unnoticed.
+    """
+    # `-o addopts=` clears the ini addopts for this child run. Two reasons:
+    # it drops the `-m "not device"` default that would otherwise fight the
+    # `-m device` here, and it drops `--verbose`, which overrides `-q` and
+    # makes collection print a `<Function ...>` tree with no node ids to count.
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "-o",
+            "addopts=",
+            "-m",
+            "device",
+            "--collect-only",
+            "-q",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    # Count collected node ids rather than matching a summary phrase. An empty
+    # selection prints "no tests collected (N deselected)" and exits 0 — the
+    # first draft of this test asserted on the absence of "no tests ran", which
+    # pytest never emits here, so it passed while zero device tests existed.
+    # That is the very failure being guarded against, one level up.
+    collected = [ln for ln in proc.stdout.splitlines() if "::" in ln]
+    assert collected, (
+        "`pytest -m device` collects nothing, so the tier-4 gate passes "
+        "vacuously — the failure #109 was opened for. Exit code was "
+        f"{proc.returncode}.\n{proc.stdout[-2000:]}"
+    )
+
+
+@pytest.mark.tier1
+@pytest.mark.unit
+def test_every_check_names_a_procedure_and_its_provenance():
+    """A checklist entry with no procedure cannot be performed, and one with
+    no issue behind it is a check nobody can justify keeping."""
+    assert CHECKS, "the device checklist is empty"
+    for check in CHECKS:
+        assert check.procedure.strip(), f"{check.id} has no procedure"
+        assert check.issues, f"{check.id} cites no issue it stands for"
+        assert check.title.strip(), f"{check.id} has no title"
+
+
+@pytest.mark.tier1
+@pytest.mark.unit
+def test_device_inventory_records_model_and_firmware():
+    """#109's own argument: "a physical Kindle" is not a record. "Paperwhite"
+    spans several revisions with known behavioural differences, so the model
+    generation and the firmware both have to be pinned."""
+    assert DEVICES, "no devices recorded"
+    for device in DEVICES.values():
+        assert device.generation, f"{device.id} has no generation recorded"
+        if device.terminal:
+            assert device.firmware, (
+                f"{device.id} is terminal, so its firmware is a constant and "
+                "must be pinned here"
+            )
+
+
+@pytest.mark.tier1
+@pytest.mark.unit
+class TestSignoffValidation:
+    """A sign-off is the per-change record #109 asks for, so an entry that
+    omits what makes it evidence has to be rejected rather than counted."""
+
+    def _result(self, **over):
+        base = {
+            "check": CHECKS[0].id,
+            "device": "paperwhite-11",
+            "firmware": "5.19.2",
+            "outcome": "pass",
+        }
+        base.update(over)
+        return base
+
+    def test_accepts_a_well_formed_pass(self):
+        assert validate_result(self._result()) == []
+
+    def test_rejects_unknown_check(self):
+        assert validate_result(self._result(check="not-a-check"))
+
+    def test_rejects_unknown_device(self):
+        assert validate_result(self._result(device="kindle-fire"))
+
+    def test_rejects_missing_firmware(self):
+        assert validate_result(self._result(firmware=""))
+
+    def test_rejects_wrong_firmware_for_a_terminal_device(self):
+        """The Oasis cannot leave 5.18.2. A sign-off claiming otherwise is a
+        transcription error, and silently trusting it would date the evidence
+        wrongly — which is the whole point of recording firmware."""
+        assert validate_result(self._result(device="oasis-10", firmware="5.19.2"))
+        assert validate_result(self._result(device="oasis-10", firmware="5.18.2")) == []
+
+    def test_rejects_unknown_outcome(self):
+        assert validate_result(self._result(outcome="probably fine"))
+
+
+@pytest.mark.tier1
+@pytest.mark.unit
+def test_results_for_selects_only_the_named_check(tmp_path):
+    signoff = {
+        "results": [
+            {
+                "check": CHECKS[0].id,
+                "device": "oasis-10",
+                "firmware": "5.18.2",
+                "outcome": "pass",
+            },
+            {
+                "check": CHECKS[1].id,
+                "device": "oasis-10",
+                "firmware": "5.18.2",
+                "outcome": "pass",
+            },
+        ]
+    }
+    path = tmp_path / "signoff.json"
+    path.write_text(json.dumps(signoff))
+    got = results_for(json.loads(path.read_text()), CHECKS[0].id)
+    assert len(got) == 1
+    assert got[0]["check"] == CHECKS[0].id
+
+
+@pytest.mark.tier1
+@pytest.mark.unit
+def test_check_by_id_round_trips():
+    for check in CHECKS:
+        assert check_by_id(check.id) is check


### PR DESCRIPTION
Closes #109.

Implements the options the issue lists, following its own read that (1) and (5) are near-free and (2) is the only one that gates mechanically.

## A correction to the issue's premise

#109 says `pytest -m device` "is a no-op that exits successfully". Measured, that is not what happens — with nothing to collect it exits **5**, `no tests collected`, which is a failure code.

The gap is narrower and different from "an empty gate reads as a pass". The tier had no **content**: nothing said what to do on the device, nothing recorded what was done, and "was this change checked on hardware?" was unanswerable. An empty selection reports the absence of *tests*, never the absence of *testing*.

That still wants fixing — it is just worth fixing for the real reason.

## What's here

**A checklist with something to collect.** Six checks, each standing for a defect that actually shipped:

| check | stands for |
|---|---|
| `toc_navigation` | #51, #62 |
| `note_round_trip` | #52, #79 |
| `body_images_render` | #102, #116 |
| `raised_text` | #115, #123, #126 |
| `contents_page` | #132, #133, #135 |
| `cover_thumbnail` | #39 |

`pytest -m device` now collects 8 tests where it collected none. They **fail rather than skip** when nothing is signed off, and the failure message *is* the procedure:

```
Navigation pane entries land on their chapter  [toc_navigation]
  stands for: #51, #62
  do: Open Go To -> Table of Contents. Tap three entries spread through the
      book, including the last one. Each must land at the start of the chapter
      it names.
  fails like: An entry does nothing, or lands at the top of the book. Every
      link kfxgen emitted once resolved against nothing (#51) and structural
      tests could not see it.
```

Skipping is how a gate goes quiet — that is #99, #92, #98 and #106.

**The hardware pinned**, as the issue's own thread settled it:

| Device | Firmware | Status |
|---|---|---|
| Oasis, 10th generation (2019) | 5.18.2 | Terminal |
| Paperwhite, 11th generation (2021) | 5.19.2 | Current |

Firmware is a constant for the Oasis and per-run for the Paperwhite, and the validator enforces that distinction: a sign-off claiming the Oasis is on anything but 5.18.2 is rejected as a transcription error rather than trusted, because silently accepting it would date the evidence wrongly.

**The record.** `scripts/device_signoff.py` writes it, `pytest -m device` reads it:

```bash
python scripts/device_signoff.py --template > signoff.json
KFXGEN_DEVICE_SIGNOFF=signoff.json pytest -m device
python scripts/device_signoff.py --summary signoff.json    # release-notes table
python scripts/device_signoff.py --trailers v5.7.2..HEAD   # per-change history
```

`--trailers` answers the question #109 says is currently unanswerable. Run over the last release it finds the one `Device-verified:` trailer already in the history, on #126 — the convention existed informally and is now written down.

**A tier-1 guard** (`tests/unit/test_device_gate.py`), running on every PR, that fails if the device marker ever collects nothing again.

**Docs**: CONTRIBUTING gains the device table, the trailer convention, and the mandatory-before-merge clause made actionable; a PR template carries the `$164`/`$417` checkbox.

## Verified discriminating, not assumed

Removing the checklist file makes the tier-1 guard fail with the pre-#109 state. Against a filled-in sign-off, each mutation fails exactly the test that should catch it:

| mutation | failures |
|---|---|
| one outcome → `fail` | 1 |
| drop a device | 1 |
| blank the build | 1 |
| claim wrong terminal firmware | 6 |
| drop a check's results | 1 |

The guard itself needed two goes: the first draft asserted on a summary phrase pytest never emits, so it passed while zero device tests existed — the same vacuity it exists to catch, one level up. It now counts collected node ids.

Suite **798 passed**.

## Not included

No CI enforcement of the trailer. CONTRIBUTING says device validation is mandatory for a class of change, but a bot that blocks merges on a commit-message convention would fire on legitimate cases and get routed around. The checkbox and the `--trailers` audit make it visible; making it blocking is a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQyQHwSL1TCdh4GsdEdhAZ