### PR TITLE
fix: keep anchor ids found in a container's inline run (#130)

### DIFF
--- a/plugin/kfxgen/converter.py
+++ b/plugin/kfxgen/converter.py
@@ -26,7 +26,6 @@ from .inline_style import (
     compute_block_style,
     make_anchor_mark,
     make_link_flag,
-    normalize_runs,
     normalize_runs_with_anchors,
     parse_vertical_align,
 )
@@ -583,12 +582,23 @@ def extract_blocks_from_html(
         def _flush_inline():
             if not inline_parts:
                 return
-            text, spans = normalize_runs(inline_parts)
+            # `normalize_runs_with_anchors`, matching the leaf-block branch.
+            # The plain version silently discards the anchor marks
+            # `_walk_inline` emits, which is why an `id` on a table cell used
+            # to vanish while the same id on a `<p>` or `<li>` survived:
+            # `table`/`tr`/`td` are not in `block_tags`, so a whole table is
+            # walked here rather than there, and a link into a cell resolved
+            # to nothing at all (#130).
+            text, spans, mark_offsets = normalize_runs_with_anchors(inline_parts)
             inline_parts.clear()
             if not text:
+                # An anchor contributing no visible text carries forward to the
+                # next block, exactly as an empty leaf block already does.
+                pending_ids.extend(mark_offsets)
                 return
             ids = pending_ids[:]
             pending_ids.clear()
+            ids.extend(mark_offsets)
             block_ids = _dedupe_keep_order(ids)
             blocks.append(
                 {
@@ -596,7 +606,13 @@ def extract_blocks_from_html(
                     "spans": spans,
                     "block_style": None,
                     "anchor_ids": block_ids,
-                    "anchor_offsets": dict.fromkeys(block_ids, 0),
+                    # Cells fuse into one block (#128), so an offset is what
+                    # makes a link land on the right cell rather than at the
+                    # start of the row. Ids inherited from an enclosing
+                    # container point at the block's start (#79).
+                    "anchor_offsets": {
+                        aid: mark_offsets.get(aid, 0) for aid in block_ids
+                    },
                 }
             )
 

--- a/tests/unit/test_converter.py
+++ b/tests/unit/test_converter.py
@@ -2585,3 +2585,100 @@ def test_generated_contents_never_labels_an_entry_with_an_image():
     assert not [e for e in entries if _conv._IMG_TOKEN_RE.search(e)], (
         f"an image token reached the contents listing: {entries}"
     )
+
+
+class TestTableCellAnchors:
+    """#130: an `id` on a table cell was discarded while the same id on any
+    other element was kept.
+
+    `table`/`tr`/`td` are not in `block_tags`, so a whole table is walked by
+    the container branch, and that branch flushed its inline run through
+    `normalize_runs` — which drops anchor marks — where the leaf-block branch
+    uses `normalize_runs_with_anchors`. A link into a cell therefore resolved
+    to nothing, which per the anchor model (#50) is a dead link rather than a
+    mislanded one.
+
+    No corpus book has ids on cells, so this shipped without symptom. The
+    inconsistency is the defect.
+    """
+
+    BASE = "text/ch1.xhtml"
+
+    def _blocks(self, markup):
+        return extract_blocks_from_html(_body_markup(markup), base_href=self.BASE)
+
+    def test_id_on_a_table_cell_is_kept(self):
+        blocks = self._blocks('<table><tr><td id="c1">1801</td></tr></table>')
+        assert blocks[0]["anchor_ids"] == ["c1"]
+
+    def test_id_on_a_header_cell_is_kept(self):
+        blocks = self._blocks('<table><tr><th id="h1">Year</th></tr></table>')
+        assert blocks[0]["anchor_ids"] == ["h1"]
+
+    def test_every_cell_id_in_a_fused_row_survives(self):
+        """Cells fuse into one block (#128), so all their ids land on it."""
+        blocks = self._blocks(
+            '<table><tr><td id="c1">1801</td><td id="c2">8,893</td></tr></table>'
+        )
+        assert blocks[0]["anchor_ids"] == ["c1", "c2"]
+
+    def test_a_fused_cell_id_records_where_its_text_starts(self):
+        """Because the row is one block, an offset is what makes a link land
+        on the right cell rather than at the start of the row (#79)."""
+        blocks = self._blocks(
+            '<table><tr><td id="c1">1801</td><td id="c2">8,893</td></tr></table>'
+        )
+        # `anchor_offsets` is re-keyed to "<file>#<id>" once `base_href` is
+        # known, so links can be matched across files (#53).
+        offsets = blocks[0]["anchor_offsets"]
+        text = blocks[0]["text"]
+        assert offsets[f"{self.BASE}#c1"] == 0
+        assert offsets[f"{self.BASE}#c2"] == text.index("8,893"), (
+            f"expected the second cell's offset to point at its own text in "
+            f"{text!r}, got {offsets[f'{self.BASE}#c2']}"
+        )
+
+    def test_a_link_into_a_cell_has_a_key_to_resolve_against(self):
+        blocks = self._blocks('<table><tr><td id="c1">1801</td></tr></table>')
+        assert f"{self.BASE}#c1" in blocks[0]["anchor_keys"]
+
+    def test_an_id_on_the_row_is_kept_too(self):
+        blocks = self._blocks('<table><tr id="r1"><td>1801</td></tr></table>')
+        assert "r1" in blocks[0]["anchor_ids"]
+
+    def test_inline_anchor_in_a_container_lead_in_survives(self):
+        """The same branch handles a container's own inline text alongside
+        block children (#58) — an anchor there was dropped for the same
+        reason."""
+        blocks = self._blocks(
+            '<div><span id="s1">Lead-in text.</span><p>A paragraph.</p></div>'
+        )
+        assert blocks[0]["text"] == "Lead-in text."
+        assert blocks[0]["anchor_ids"] == ["s1"]
+
+    def test_ids_carried_in_from_an_earlier_empty_anchor_still_arrive(self):
+        """Guard: ids waiting in `pending_ids` must not be lost when the
+        flushed run now contributes ids of its own."""
+        blocks = self._blocks(
+            '<a id="before"></a><table><tr><td id="c1">1801</td></tr></table>'
+        )
+        assert blocks[0]["anchor_ids"] == ["before", "c1"]
+        assert blocks[0]["anchor_offsets"][f"{self.BASE}#before"] == 0
+
+    def test_an_anchor_inside_a_cell_is_kept(self):
+        """The shape that actually occurs. #130 measured ids *on* `<td>`/`<th>`
+        and found none in the corpus, concluding the defect had no instances.
+        Real books put the id on an inline element *inside* the cell — one
+        corpus book has 443 of them — and those take the same dropped path."""
+        blocks = self._blocks('<table><tr><td><a id="p1"></a>1801</td></tr></table>')
+        assert "p1" in blocks[0]["anchor_ids"]
+
+    def test_a_span_id_inside_a_cell_is_kept(self):
+        blocks = self._blocks(
+            '<table><tr><td><span id="s1">1801</span></td></tr></table>'
+        )
+        assert "s1" in blocks[0]["anchor_ids"]
+
+    def test_a_cell_without_an_id_adds_nothing(self):
+        blocks = self._blocks("<table><tr><td>1801</td></tr></table>")
+        assert blocks[0]["anchor_ids"] == []


### PR DESCRIPTION
Closes #130.

## The bug, as filed

`_walk`'s container branch flushed its inline run through `normalize_runs`, which silently discards the anchor marks `_walk_inline` emits, where the leaf-block branch uses `normalize_runs_with_anchors`. Any id inside a container-walked subtree vanished, and a link to it resolved to nothing.

`table`/`tr`/`td` aren't in `block_tags`, which is why tables were the visible face of it — a whole table goes through the container branch.

## The issue's impact measurement is wrong, and that's the point

#130 says:

> **Measured impact: none observed** — books with ids on cells: 0, of those, with links into them: 0. So this is a correctness gap with no instance in the corpus.

That scan looked for ids **on** `<td>`/`<th>`. Real books put the id on an inline element **inside** the cell — `<td><a id="page12"></a>1801</td>` — and those take the same dropped path. One corpus book has **443** such ids.

Measured across all 77 books, converting each with `main` and with this branch:

| | main | this branch | |
|---|---|---|---|
| books changed | | 8 of 77 | |
| anchors | 15,545 | 16,005 | +460 |
| **link spans** | **21,516** | **21,991** | **+475** |
| dangling | 0 | 0 | unchanged |

| book | link spans |
|---|---|
| pg12082 | 6 → **241** |
| pg21053 | 979 → 1,178 |
| pg28428 | 3,210 → 3,244 |
| pg1342 | 100 → 102 |

kfxgen *drops* a link whose target won't resolve rather than emitting a dangling one, so these 475 links were dying silently — invisible to the `dangling == 0` assertion, which is satisfied by emitting nothing at all.

This is not "a correctness gap with no instances". It is a live defect in 8 of 77 books, and in pg12082 it was costing 97% of the book's links.

## Offsets come along too

Cells fuse into one block (#128). Without offsets every link into a row would land at the row's start rather than on its cell, so the ids carry their character offsets exactly as the leaf branch does (#79). Ids inherited from an enclosing container keep offset 0.

## Tests

Eleven, covering: an id on a cell, an id **inside** a cell (the shape that actually occurs), header cells, rows, fused-row offsets, the anchor key a link resolves against, a container lead-in, the pending-id carry, and a control with no id.

Mutation-verified: restoring the dropped-marks behaviour fails 8 of the 11.

## Verification

- goldens byte-identical — `tier3_strict` 13 passed
- corpus sweep 154 passed, dangling still 0
- suite **834 passed**
- also drops the now-unused `normalize_runs` import; this was its last call site

## Device check

#130 notes that anything changing link landing wants a device check, per #50's paragraph-granularity model. Not done here. It is a good first candidate for the `note_round_trip` and `toc_navigation` entries in the tier-4 checklist that just landed in #140 — links into a fused table row are exactly the case where a wrong offset shows up as landing on the wrong cell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VQyQHwSL1TCdh4GsdEdhAZ